### PR TITLE
Missing Chart in ofdm_demod_c.m

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,11 +333,11 @@ if(UNITTEST)
              set_tests_properties(test_FSK_modem_mod_demod  PROPERTIES PASS_REGULAR_EXPRESSION "bits tested 9800, bit errors 0")
 
     add_test(NAME test_FreeDV_API_700D_AWGN_BER
-             COMMAND sh -c "dd bs=1280 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard"
+             COMMAND sh -c "dd bs=1280 count=500 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard"
              )
 
     add_test(NAME test_FreeDV_API_700D_AWGN_BER_Interleave
-             COMMAND sh -c "dd bs=1280 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --interleave 8 --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --interleave 8 --testframes"
+             COMMAND sh -c "dd bs=1280 count=800 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --interleave 8 --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --interleave 8 --testframes"
              )
 
 endif(UNITTEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,11 +333,11 @@ if(UNITTEST)
              set_tests_properties(test_FSK_modem_mod_demod  PROPERTIES PASS_REGULAR_EXPRESSION "bits tested 9800, bit errors 0")
 
     add_test(NAME test_FreeDV_API_700D_AWGN_BER
-             COMMAND sh -c "dd bs=1280 count=500 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard"
+             COMMAND sh -c "dd bs=1280 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard"
              )
 
     add_test(NAME test_FreeDV_API_700D_AWGN_BER_Interleave
-             COMMAND sh -c "dd bs=1280 count=800 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --interleave 8 --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --interleave 8 --testframes"
+             COMMAND sh -c "dd bs=1280 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --interleave 8 --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --interleave 8 --testframes"
              )
 
 endif(UNITTEST)

--- a/octave/ofdm_demod_c.m
+++ b/octave/ofdm_demod_c.m
@@ -41,7 +41,7 @@ function ofdm_demod_c(filename)
   title('Fine Freq');
   ylabel('Hz')
 
-  figure(4); clf;
+  figure(5); clf;
   plot(snr_est_log_c);
   ylabel('SNR (dB)')
   title('SNR Estimates')

--- a/src/codec2_ofdm.h
+++ b/src/codec2_ofdm.h
@@ -62,9 +62,9 @@ void ofdm_destroy(struct OFDM *);
 
 void ofdm_mod(struct OFDM *, COMP *, const int *);
 void ofdm_demod(struct OFDM *, int *, COMP *);
-void ofdm_demod_shorts(struct OFDM *, int *, short *, float);
+void ofdm_demod_shorts(struct OFDM *, int *, short *);
 int  ofdm_sync_search(struct OFDM *, COMP *);
-int  ofdm_sync_search_shorts(struct OFDM *, short *, float);
+int  ofdm_sync_search_shorts(struct OFDM *, short *);
 void ofdm_sync_state_machine(struct OFDM *, uint8_t *);
 
 /* getters */

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -1799,8 +1799,6 @@ static int freedv_comprx_700d(struct freedv *f, short demod_in_8kHz[], float gai
     int parityCheckCount = 0;
     uint8_t rx_uw[ofdm_nuwbits];
 
-    float new_gain = gain / OFDM_AMP_SCALE;
-    
     /* echo samples back out as default (say if sync not found) */
     
     *valid = 1;
@@ -1813,13 +1811,13 @@ static int freedv_comprx_700d(struct freedv *f, short demod_in_8kHz[], float gai
     /* looking for modem sync */
     
     if (ofdm->sync_state == search) {
-        ofdm_sync_search_shorts(f->ofdm, demod_in_8kHz, new_gain);
+        ofdm_sync_search_shorts(f->ofdm, demod_in_8kHz);
     }
 
      /* OK modem is in sync */
     
     if ((ofdm->sync_state == synced) || (ofdm->sync_state == trial)) {
-        ofdm_demod_shorts(ofdm, rx_bits, demod_in_8kHz, new_gain);
+        ofdm_demod_shorts(ofdm, rx_bits, demod_in_8kHz);
         ofdm_disassemble_modem_frame(ofdm, rx_uw, payload_syms, payload_amps, txt_bits);
 
         f->sync = 1;

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -150,7 +150,7 @@ int  freedv_data_ntxframes (struct freedv *freedv);
 
 int freedv_nin      (struct freedv *freedv);
 int freedv_rx       (struct freedv *freedv, short speech_out[], short demod_in[]);
-int freedv_shortrx  (struct freedv *freedv, short speech_out[], short demod_in[], float gain);
+int freedv_shortrx  (struct freedv *freedv, short speech_out[], short demod_in[]);
 int freedv_floatrx  (struct freedv *freedv, short speech_out[], float demod_in[]);
 int freedv_comprx   (struct freedv *freedv, short speech_out[], COMP  demod_in[]);
 int freedv_codecrx  (struct freedv *freedv, unsigned char *packed_codec_bits, short demod_in[]);

--- a/src/horus_api.c
+++ b/src/horus_api.c
@@ -378,9 +378,10 @@ int horus_rx(struct horus *hstates, char ascii_out[], short demod_in[]) {
     COMP *demod_in_comp = (COMP*)malloc(sizeof(COMP)*hstates->fsk->nin);
     
     for (i=0; i<hstates->fsk->nin; i++) {
-        demod_in_comp[i].real = demod_in[i];
-        demod_in_comp[i].imag = 0;
+        demod_in_comp[i].real = (float) demod_in[i] / 32767.0f;
+        demod_in_comp[i].imag = 0.0f;
     }
+
     fsk_demod(hstates->fsk, &hstates->rx_bits[rx_bits_len-Nbits], demod_in_comp);
     free(demod_in_comp);
     
@@ -398,14 +399,18 @@ int horus_rx(struct horus *hstates, char ascii_out[], short demod_in[]) {
         if (hstates->mode == HORUS_MODE_RTTY) {
             packet_detected = extract_horus_rtty(hstates, ascii_out, uw_loc);
         }
+
         if (hstates->mode == HORUS_MODE_BINARY) {
             packet_detected = extract_horus_binary(hstates, ascii_out, uw_loc);
             //#define DUMP_BINARY_PACKET
             #ifdef DUMP_BINARY_PACKET
-            FILE *f = fopen("packetbits.txt", "wt"); assert(f != NULL);
+            FILE *f = fopen("packetbits.txt", "wt");
+            assert(f != NULL);
+
             for(i=0; i<hstates->max_packet_len; i++) {
                 fprintf(f,"%d ", hstates->rx_bits[uw_loc+i]);
             }
+
             fclose(f);
             exit(0);
             #endif
@@ -502,3 +507,4 @@ void horus_set_total_payload_bits(struct horus *hstates, int val) {
     assert(hstates != NULL);
     hstates->total_payload_bits = val;
 }
+

--- a/src/horus_demod.c
+++ b/src/horus_demod.c
@@ -178,8 +178,10 @@ int main(int argc, char *argv[]) {
         if (verbose) {
             fprintf(stderr, "read nin %d\n", horus_nin(hstates));
         }
+
         if (horus_rx(hstates, ascii_out, demod_in)) {
             fprintf(stdout, "%s", ascii_out);
+
             if (crc_results) {
                 if (horus_crc_ok(hstates)) {
                     fprintf(stdout, "  CRC OK");
@@ -187,6 +189,7 @@ int main(int argc, char *argv[]) {
                     fprintf(stdout, "  CRC BAD");
                 }
             }
+
             fprintf(stdout, "\n");
         }
         
@@ -208,15 +211,23 @@ int main(int argc, char *argv[]) {
 	    /* Print the eye diagram */
 
             fprintf(stderr,",\t\"eye_diagram\":[");
-            for(i=0;i<stats.neyetr;i++){
+
+            for (i = 0; i < stats.neyetr; i++) {
                 fprintf(stderr,"[");
-                for(j=0;j<stats.neyesamp;j++){
+
+                for (j = 0; j < stats.neyesamp; j++) {
                     fprintf(stderr,"%f ",stats.rx_eye[i][j]);
-                    if(j<stats.neyesamp-1) fprintf(stderr,",");
+
+                    if (j < stats.neyesamp-1)
+                        fprintf(stderr,",");
                 }
+
                 fprintf(stderr,"]");
-                if(i<stats.neyetr-1) fprintf(stderr,",");
+
+                if (i < stats.neyetr-1)
+                    fprintf(stderr,",");
             }
+
             fprintf(stderr,"],");
 	    
 	    fprintf(stderr,"\"samp_fft\":[");
@@ -227,18 +238,24 @@ int main(int argc, char *argv[]) {
 	    /* Print a sample of the FFT from the freq estimator */
 
 	    Ndft = hstates->fsk->Ndft/2;
-	    for(i=0; i<Ndft; i++){
+
+	    for (i = 0; i < Ndft; i++){
 		fprintf(stderr,"%f ",(hstates->fsk->fft_est)[i]);
-		if(i<Ndft-1) fprintf(stderr,",");
+		
+                if(i<Ndft-1)
+                    fprintf(stderr, ",");
 	    }
             #else
 
             /* All zero dummy data for now */
 
  	    Ndft = 128;
-	    for(i=0; i<Ndft; i++) {
+
+	    for (i = 0; i < Ndft; i++) {
 		fprintf(stderr,"%f ", 0.0);
-		if(i<Ndft-1) fprintf(stderr,",");
+		
+                if (i < Ndft-1)
+                    fprintf(stderr, ",");
 	    }
             
             #endif
@@ -246,9 +263,10 @@ int main(int argc, char *argv[]) {
 	    fprintf(stderr,"]}\n");
             stats_ctr = stats_loop;
         }
+
         stats_ctr--;
 
-        if (fin == stdin || fout == stdin){
+        if (fin == stdin || fout == stdin) {
             fflush(fin);
             fflush(fout);
         }

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -950,7 +950,7 @@ int ofdm_sync_search(struct OFDM *ofdm, COMP *rxbuf_in) {
  * This is a wrapper with a new interface to reduce memory allocated.
  * This works with ofdm_demod and freedv_api.
  */
-int ofdm_sync_search_shorts(struct OFDM *ofdm, short *rxbuf_in, float gain) {
+int ofdm_sync_search_shorts(struct OFDM *ofdm, short *rxbuf_in) {
     int i, j;
 
     /* shift the buffer left based on nin */
@@ -960,7 +960,7 @@ int ofdm_sync_search_shorts(struct OFDM *ofdm, short *rxbuf_in, float gain) {
     /* insert latest input samples onto tail of rxbuf */
 
     for (i = (ofdm_rxbuf - ofdm->nin), j = 0; i < ofdm_rxbuf; i++, j++) {
-        ofdm->rxbuf[i] = (((float) rxbuf_in[j] / 32767.0f) * gain) + 0.0f * I;
+        ofdm->rxbuf[i] = ((float) rxbuf_in[j] / 32767.0f) + 0.0f * I;
     }
 
     return ofdm_sync_search_core(ofdm);
@@ -1034,7 +1034,7 @@ void ofdm_demod(struct OFDM *ofdm, int *rx_bits, COMP *rxbuf_in) {
  * This is a wrapper with a new interface to reduce memory allocated.
  * This works with ofdm_demod and freedv_api
  */
-void ofdm_demod_shorts(struct OFDM *ofdm, int *rx_bits, short *rxbuf_in, float gain) {
+void ofdm_demod_shorts(struct OFDM *ofdm, int *rx_bits, short *rxbuf_in) {
     int i, j;
 
     /* shift the buffer left based on nin */
@@ -1046,7 +1046,7 @@ void ofdm_demod_shorts(struct OFDM *ofdm, int *rx_bits, short *rxbuf_in, float g
     /* insert latest input samples onto tail of rxbuf */
     
     for (i = (ofdm_rxbuf - ofdm->nin), j = 0; i < ofdm_rxbuf; i++, j++) {
-        ofdm->rxbuf[i] = (((float) rxbuf_in[j] / 32767.0f) * gain) + 0.0f * I;
+        ofdm->rxbuf[i] = ((float) rxbuf_in[j] / 32767.0f) + 0.0f * I;
     }
 
     ofdm_demod_core(ofdm, rx_bits);

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -960,7 +960,7 @@ int ofdm_sync_search_shorts(struct OFDM *ofdm, short *rxbuf_in, float gain) {
     /* insert latest input samples onto tail of rxbuf */
 
     for (i = (ofdm_rxbuf - ofdm->nin), j = 0; i < ofdm_rxbuf; i++, j++) {
-        ofdm->rxbuf[i] = ((float)rxbuf_in[j] * gain);
+        ofdm->rxbuf[i] = (rxbuf_in[j] / 32768.0f * gain) + 0.0f * I;
     }
 
     return ofdm_sync_search_core(ofdm);
@@ -1046,7 +1046,7 @@ void ofdm_demod_shorts(struct OFDM *ofdm, int *rx_bits, short *rxbuf_in, float g
     /* insert latest input samples onto tail of rxbuf */
     
     for (i = (ofdm_rxbuf - ofdm->nin), j = 0; i < ofdm_rxbuf; i++, j++) {
-        ofdm->rxbuf[i] = ((float)rxbuf_in[j] * gain);
+        ofdm->rxbuf[i] = ((rxbuf_in[j] / 32768.0f) * gain) + 0.0f * I;
     }
 
     ofdm_demod_core(ofdm, rx_bits);

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -960,7 +960,7 @@ int ofdm_sync_search_shorts(struct OFDM *ofdm, short *rxbuf_in, float gain) {
     /* insert latest input samples onto tail of rxbuf */
 
     for (i = (ofdm_rxbuf - ofdm->nin), j = 0; i < ofdm_rxbuf; i++, j++) {
-        ofdm->rxbuf[i] = ((rxbuf_in[j] / 32768.0f) * gain) + 0.0f * I;
+        ofdm->rxbuf[i] = (((float) rxbuf_in[j] / 32767.0f) * gain) + 0.0f * I;
     }
 
     return ofdm_sync_search_core(ofdm);
@@ -1046,7 +1046,7 @@ void ofdm_demod_shorts(struct OFDM *ofdm, int *rx_bits, short *rxbuf_in, float g
     /* insert latest input samples onto tail of rxbuf */
     
     for (i = (ofdm_rxbuf - ofdm->nin), j = 0; i < ofdm_rxbuf; i++, j++) {
-        ofdm->rxbuf[i] = ((rxbuf_in[j] / 32768.0f) * gain) + 0.0f * I;
+        ofdm->rxbuf[i] = (((float) rxbuf_in[j] / 32767.0f) * gain) + 0.0f * I;
     }
 
     ofdm_demod_core(ofdm, rx_bits);

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -960,7 +960,7 @@ int ofdm_sync_search_shorts(struct OFDM *ofdm, short *rxbuf_in, float gain) {
     /* insert latest input samples onto tail of rxbuf */
 
     for (i = (ofdm_rxbuf - ofdm->nin), j = 0; i < ofdm_rxbuf; i++, j++) {
-        ofdm->rxbuf[i] = (rxbuf_in[j] / 32768.0f * gain) + 0.0f * I;
+        ofdm->rxbuf[i] = ((rxbuf_in[j] / 32768.0f) * gain) + 0.0f * I;
     }
 
     return ofdm_sync_search_core(ofdm);

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -441,11 +441,11 @@ int main(int argc, char *argv[]) {
         /* demod */
 
         if (ofdm->sync_state == search) {
-            ofdm_sync_search_shorts(ofdm, rx_scaled, (OFDM_AMP_SCALE / 2.0f));
+            ofdm_sync_search_shorts(ofdm, rx_scaled);
         }
 
         if ((ofdm->sync_state == synced) || (ofdm->sync_state == trial)) {
-            ofdm_demod_shorts(ofdm, rx_bits, rx_scaled, (OFDM_AMP_SCALE / 2.0f));
+            ofdm_demod_shorts(ofdm, rx_bits, rx_scaled);
             ofdm_disassemble_modem_frame(ofdm, rx_uw, payload_syms, payload_amps, txt_bits);
             log_payload_syms = true;
 


### PR DESCRIPTION
When viewing the code to see exactly what this program was displaying, I noticed that figure 4 was used twice, so renamed the last one figure 5, and the missing chart now displays.