### PR TITLE
OFDM Receive Buffer Amplitude Reduction

### DIFF
--- a/octave/ofdm_demod_c.m
+++ b/octave/ofdm_demod_c.m
@@ -41,7 +41,7 @@ function ofdm_demod_c(filename)
   title('Fine Freq');
   ylabel('Hz')
 
-  figure(4); clf;
+  figure(5); clf;
   plot(snr_est_log_c);
   ylabel('SNR (dB)')
   title('SNR Estimates')

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -948,7 +948,7 @@ int ofdm_sync_search(struct OFDM *ofdm, COMP *rxbuf_in) {
 
 /*
  * This is a wrapper with a new interface to reduce memory allocated.
- * This works with ofdm_demod and freedv_api.
+ * This works with ofdm_demod and freedv_api. Gain is not used here.
  */
 int ofdm_sync_search_shorts(struct OFDM *ofdm, short *rxbuf_in, float gain) {
     int i, j;
@@ -960,7 +960,7 @@ int ofdm_sync_search_shorts(struct OFDM *ofdm, short *rxbuf_in, float gain) {
     /* insert latest input samples onto tail of rxbuf */
 
     for (i = (ofdm_rxbuf - ofdm->nin), j = 0; i < ofdm_rxbuf; i++, j++) {
-        ofdm->rxbuf[i] = ((float)rxbuf_in[j] * gain);
+        ofdm->rxbuf[i] = ((float)rxbuf_in[j] / 32767.0f);
     }
 
     return ofdm_sync_search_core(ofdm);
@@ -1032,7 +1032,7 @@ void ofdm_demod(struct OFDM *ofdm, int *rx_bits, COMP *rxbuf_in) {
 
 /*
  * This is a wrapper with a new interface to reduce memory allocated.
- * This works with ofdm_demod and freedv_api
+ * This works with ofdm_demod and freedv_api. Gain is not used here.
  */
 void ofdm_demod_shorts(struct OFDM *ofdm, int *rx_bits, short *rxbuf_in, float gain) {
     int i, j;
@@ -1046,7 +1046,7 @@ void ofdm_demod_shorts(struct OFDM *ofdm, int *rx_bits, short *rxbuf_in, float g
     /* insert latest input samples onto tail of rxbuf */
     
     for (i = (ofdm_rxbuf - ofdm->nin), j = 0; i < ofdm_rxbuf; i++, j++) {
-        ofdm->rxbuf[i] = ((float)rxbuf_in[j] * gain);
+        ofdm->rxbuf[i] = ((float)rxbuf_in[j] / 32767.0f);
     }
 
     ofdm_demod_core(ofdm, rx_bits);


### PR DESCRIPTION
This changes the way shorts are imported into the rxbuf, by first dividing by 32767.0 in order to put it in the range of +/- 1.0. Also the gain is not used, but since other modems use this parameter I left it in.

Good BER, good tests.

```
test 10
    Start 10: test_FreeDV_API_700D_AWGN_BER

10: BER......: 0.0829 Tbits: 13392 Terrs:  1110
10: Coded BER: 0.0055 Tbits:  6048 Terrs:    33
1/2 Test #10: test_FreeDV_API_700D_AWGN_BER ..............   Passed    0.31 sec

test 11
    Start 11: test_FreeDV_API_700D_AWGN_BER_Interleave

11: BER......: 0.0834 Tbits: 10030 Terrs:   837
11: Coded BER: 0.0047 Tbits:  4480 Terrs:    21
2/2 Test #11: test_FreeDV_API_700D_AWGN_BER_Interleave ...   Passed    0.29 sec
```