### PR TITLE
Removed implict double promotion and other warnings

### DIFF
--- a/src/cohpsk.c
+++ b/src/cohpsk.c
@@ -141,7 +141,7 @@ struct COHPSK *cohpsk_create(void)
 
         /* note non-linear carrier spacing to help PAPR, works v well in conjunction with CLIP */
 
-        freq_hz = fdmdv->fsep*( -(COHPSK_NC*ND)/2 - 0.5 + pow(c + 1.0, 0.98) );
+        freq_hz = fdmdv->fsep*( -(COHPSK_NC*ND)/2 - 0.5 + powf(c + 1.0, 0.98) );
 
 	fdmdv->freq[c].real = cosf(2.0*M_PI*freq_hz/COHPSK_FS);
  	fdmdv->freq[c].imag = sinf(2.0*M_PI*freq_hz/COHPSK_FS);
@@ -943,8 +943,8 @@ void rate_Fs_rx_processing(struct COHPSK *coh, COMP ch_symb[][COHPSK_NC*ND], COM
             /* loop filter made up of 1st order IIR plus integrator.  Integerator
                was found to be reqd  */
 
-            fdmdv->foff_filt = (1.0-beta)*fdmdv->foff_filt + beta*atan2(mod_strip.imag, mod_strip.real);
-            //printf("foff_filt: %f angle: %f\n", fdmdv->foff_filt, atan2(mod_strip.imag, mod_strip.real));
+            fdmdv->foff_filt = (1.0-beta)*fdmdv->foff_filt + beta*atan2f(mod_strip.imag, mod_strip.real);
+            //printf("foff_filt: %f angle: %f\n", fdmdv->foff_filt, atan2f(mod_strip.imag, mod_strip.real));
             *f_est += g*fdmdv->foff_filt;
         }
 
@@ -1127,7 +1127,7 @@ void cohpsk_demod(struct COHPSK *coh, float rx_bits[], int *sync_good, COMP rx_f
             */
              frame_sync_fine_freq_est(coh, &ch_symb[(NSW-1)*NSYMROWPILOT], sync, &next_sync);
 
-            if (fabs(coh->f_fine_est) > 2.0) {
+            if (fabsf(coh->f_fine_est) > 2.0) {
                 if (coh->verbose)
                     fprintf(stderr, "  [%d] Hmm %f is a bit big :(\n", coh->frame, (double)coh->f_fine_est);
                 next_sync = 0;
@@ -1200,7 +1200,7 @@ void cohpsk_demod(struct COHPSK *coh, float rx_bits[], int *sync_good, COMP rx_f
 
 int cohpsk_fs_offset(COMP out[], COMP in[], int n, float sample_rate_ppm)
 {
-    double tin, f;
+    float tin, f;
     int   tout, t1, t2;
 
     tin = 0.0; tout = 0;

--- a/src/newamp1.c
+++ b/src/newamp1.c
@@ -106,7 +106,7 @@ void mel_sample_freqs_kHz(float rate_K_sample_freqs_kHz[], int K, float mel_star
 
     mel = mel_start;
     for (k=0; k<K; k++) {
-        rate_K_sample_freqs_kHz[k] = 0.7*(pow(10.0, (mel/2595.0)) - 1.0);
+        rate_K_sample_freqs_kHz[k] = 0.7*(POW10F(mel/2595.0) - 1.0);
         mel += step;
     }
 }
@@ -131,7 +131,7 @@ void resample_const_rate_f(C2CONST *c2const, MODEL *model, float rate_K_vec[], f
 
     AmdB_peak = -100.0;
     for(m=1; m<=model->L; m++) {
-        AmdB[m] = 20.0*log10(model->A[m]+1E-16);
+        AmdB[m] = 20.0*log10f(model->A[m]+1E-16);
         if (AmdB[m] > AmdB_peak) {
             AmdB_peak = AmdB[m];
         }
@@ -351,7 +351,7 @@ void resample_rate_L(C2CONST *c2const, MODEL *model, float rate_K_vec[], float r
 
    interp_para(&AmdB[1], rate_K_sample_freqs_kHz_term, rate_K_vec_term, K+2, &rate_L_sample_freqs_kHz[1], model->L);    
    for(m=1; m<=model->L; m++) {
-       model->A[m] = pow(10.0,  AmdB[m]/20.0);
+       model->A[m] = POW10F(AmdB[m]/20.0);
        // printf("m: %d f: %f AdB: %f A: %f\n", m, rate_L_sample_freqs_kHz[m], AmdB[m], model->A[m]);
    }
 }

--- a/src/test_bits_ofdm.h
+++ b/src/test_bits_ofdm.h
@@ -241,7 +241,7 @@ const int test_bits_ofdm[]={
   0
 };
 
-const int payload_data_bits[]={
+const uint8_t payload_data_bits[]={
   1,
   1,
   0,

--- a/stm32/cmake/STM32_Lib.cmake
+++ b/stm32/cmake/STM32_Lib.cmake
@@ -345,3 +345,4 @@ ${CMSIS}/DSP_Lib/Source/TransformFunctions/arm_rfft_q31.c
 )
 
 add_library(CMSIS STATIC ${CMSIS_SRCS})
+target_compile_options(CMSIS PRIVATE "-Wno-double-promotion")

--- a/stm32/src/sm2000_stw.c
+++ b/stm32/src/sm2000_stw.c
@@ -70,7 +70,7 @@ int main(void) {
     uint64_t freq_in_Hz_times_100;
     struct FSK * fsk;
     struct freedv_vhf_deframer * deframer;
-    float * mod_buf;
+    float* mod_buf;
     
     sm1000_leds_switches_init();
     led_pwr(1);
@@ -82,7 +82,7 @@ int main(void) {
 		led_err(1);
 		while(1);
 	}
-    mod_buf = malloc(sizeof(float)*fsk->Nmem);
+    mod_buf = malloc(sizeof(*mod_buf)*fsk->Nmem);
     init_debug_blinky();
     txrx_12V(0);
 
@@ -146,7 +146,7 @@ int main(void) {
 				}
 				if(mbptr>=nin){
 					led_rt(1);
-					fsk_demod(fsk,bit_buf,mod_buf);
+					fsk_demod(fsk,bit_buf,(COMP*)mod_buf);
 					led_rt(0);
 					if(fvhff_deframe_bits(deframer,c2_buffer,NULL,NULL,bit_buf)){
 						led_err(1);		

--- a/stm32/unittest/src/tst_ofdm_demod.c
+++ b/stm32/unittest/src/tst_ofdm_demod.c
@@ -79,7 +79,7 @@
 
 #define NDISCARD 20
 
-extern const int payload_data_bits[];
+extern const uint8_t payload_data_bits[];
 extern const int test_bits_ofdm[];
 
 static struct OFDM_CONFIG *ofdm_config;


### PR DESCRIPTION
Mostly by using the float returning function instead of the function returning doubles
Hide warnings in external StdPeriph lib code via compiler option

It complements some other pull requests. 