### PR TITLE
Modification to add pilots to Stats

### DIFF
--- a/src/modem_stats.h
+++ b/src/modem_stats.h
@@ -35,7 +35,12 @@
 #include "comp.h"
 #include "kiss_fft.h"
 
+#if defined(PILOT_STATS)
+#define MODEM_STATS_NC_MAX      64
+#else
 #define MODEM_STATS_NC_MAX      20
+#endif
+
 #define MODEM_STATS_NR_MAX      8
 #define MODEM_STATS_ET_MAX      8
 #define MODEM_STATS_EYE_IND_MAX 160     
@@ -69,6 +74,10 @@ struct MODEM_STATS {
 
     float        fft_buf[2*MODEM_STATS_NSPEC];
     kiss_fft_cfg fft_cfg;
+
+#if defined(PILOT_STATS)
+    float  rx_pilots[4][MODEM_STATS_NC_MAX];
+#endif
 };
 
 void modem_stats_open(struct MODEM_STATS *f);

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -1677,9 +1677,11 @@ void ofdm_get_demod_stats(struct OFDM *ofdm, struct MODEM_STATS *stats) {
     assert(ofdm_rowsperframe < MODEM_STATS_NR_MAX);
     stats->nr = ofdm_rowsperframe;
 
-    /* Just copy data frames */
-
-    for (c = 1; c < (ofdm_nc + 1); c++) {
+    /*
+     * Just copy data frames
+     * Note: rx_np[] does not contain edge pilots
+     */
+    for (c = 0; c < ofdm_nc; c++) {
         for (r = 0; r < ofdm_rowsperframe; r++) {
             complex float rot = ofdm->rx_np[r * c] * cmplx(ROT45);
 
@@ -1689,6 +1691,8 @@ void ofdm_get_demod_stats(struct OFDM *ofdm, struct MODEM_STATS *stats) {
     }
 
 #if defined(PILOT_STATS)
+    /* This includes edge pilots */
+
     for (c = 0; c < (ofdm_nc + 2); c++) {
         stats->rx_pilots[0][c] = rx_pilots[0][c];  // previous
         stats->rx_pilots[1][c] = rx_pilots[1][c];  // this

--- a/src/ofdm_internal.h
+++ b/src/ofdm_internal.h
@@ -33,6 +33,8 @@ extern "C"
 {
 #endif
 
+#undef PILOT_STATS /* Define for pilot modem stats */
+
 #include <complex.h>
 #include <stdbool.h>
 #include <stdint.h>


### PR DESCRIPTION
Fixes a bug in ofdm_get_demod_stats() to use the correct carriers in rx_symbols.

originally it copied carriers 0 to 16 where I think it should be using carriers 1 to 17 as the first and last carriers are just used by the pilots. and this section is for the data carriers.

Also

Adds another "optional" Stat which is the four pilot symbols (previous, this, next, future). By collecting these stats I envision a display view in a GUI or analysis program.