### PR TITLE
700D freedx_rx working with shorts and complex input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,10 @@ if(UNITTEST)
              COMMAND sh -c "dd bs=1280 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard"
              )
 
+    add_test(NAME test_FreeDV_API_700D_AWGN_BER_USECOMPLEX
+             COMMAND sh -c "dd bs=1280 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard --usecomplex"
+             )
+           
     add_test(NAME test_FreeDV_API_700D_AWGN_BER_Interleave
              COMMAND sh -c "dd bs=1280 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --interleave 8 --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --interleave 8 --testframes"
              )

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -2001,9 +2001,7 @@ int freedv_comprx(struct freedv *f, short speech_out[], COMP demod_in[]) {
     }
 
     if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)) {
-        short x[f->nin];
-        for(int i=0; i<f->nin; i++) x[i] = demod_in[i].real;
-        nout = freedv_comp_short_rx_700d(f, (void*)demod_in, 0, 1.0, &valid);
+        nout = freedv_comp_short_rx_700d(f, demod_in, 0, 1.0, &valid);
     }
     
     if (valid == 0) {
@@ -2056,7 +2054,7 @@ int freedv_shortrx(struct freedv *f, short speech_out[], short demod_in[], float
 
     // At this stage short interface only supported for 700D, to help
     // memory requirements on stm32
-    assert(FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode));
+    assert(f->mode == FREEDV_MODE_700D);
     
     assert(f->nin <= f->n_max_modem_samples);
 

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -944,10 +944,9 @@ int ofdm_sync_search(struct OFDM *ofdm, COMP *rxbuf_in) {
 
     memcpy(&ofdm->rxbuf[0], &ofdm->rxbuf[ofdm->nin],
         (ofdm_rxbuf - ofdm->nin) * sizeof (complex float));
-    
     memcpy(&ofdm->rxbuf[(ofdm_rxbuf - ofdm->nin)],
-        rx, (ofdm_rxbuf - ofdm->nin) * sizeof (complex float));
-
+        rx, ofdm->nin * sizeof (complex float));
+    
     return(ofdm_sync_search_core(ofdm));
 }
 


### PR DESCRIPTION
Building on @donmr 's fine work for low memory short array inputs.  We wish to provide complex float sample input for 700D as well, without changing the low memory short array functionality.  Complex input also useful for @db4ple 's projects (saves a SSB filter).

700D with optimised short code path:
```
/codec2/build_linux/src$ ./freedv_tx 700D ../../raw/ve9qrp.raw - - | ./freedv_rx 700D - -  | aplay -f S16_LE
```
700D with complex valued code path:
```
/codec2/build_linux/src$ ./freedv_tx 700D ../../raw/ve9qrp.raw - - | ./freedv_rx 700D - -  --usecomplex | aplay -f S16_LE
```

I'm sure this is non-optimal (lots of repeated code), but just looking to get a working 700d freedv_comprx() function for this PR, as I need similar code for FreeDV 2020.

Do we have any way to Ctest the full speech path?  Guess we could use a BER test, as modem performance will be sensitive to bugs the complex code path, we just won't be testing the speech decoding parts of the code.