### PR TITLE
Documentation changes and alignment of .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,8 @@ install:
     - if [ ! -e $GCC_DIR/bin/arm-none-eabi-g++ ]; then wget -q $GCC_URL -O $GCC_ARCHIVE; tar xfj $GCC_ARCHIVE -C $HOME; fi
     - export CODEC2DEV=${PWD}
     - export MAKEFLAGS=-j2 
-    - export BUILDDIR=${PWD}/build
-    - export BUILDSTD=${BUILDDIR}/normal
-    - export BUILDSTM=${BUILDDIR}/stm32
+    - export BUILDSTD=${CODEC2DEV}/build_linux
+    - export BUILDSTM=${CODEC2DEV}/stm32/build_stm32
     - export STDLIBDIR=$HOME/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0
     - if [ ! "$STDLIBURL" == "" ]; then pwd; wget -q $STDLIBURL; 7z  x -p$STDLIBKEY -o$HOME stdperiph_lib.zip; fi
 script:

--- a/INSTALL
+++ b/INSTALL
@@ -12,7 +12,8 @@ To compile codec2 a basic development environment and cmake are required.
 If they are not installed, at a command prompt, type
 
 Debian/Ubuntu distros:
-$ sudo apt-get install build-essential cmake 
+$ sudo apt-get install build-essential cmake libspeexdsp-dev libsamplerate0-dev
+ 
 
 Fedora/RH distros:
 $ sudo dnf groupinstall "Development Tools" \
@@ -20,7 +21,10 @@ $ sudo dnf groupinstall "Development Tools" \
 $ sudo dnf install cmake samplerate-devel speexdsp-devel
 
 To test the cmake build make a directory anywhere underneath (or outside of)
-the source directory.
+the source directory. 
+
+However, it is recommended to use the 'build_linux' inside the 
+codec2 source tree as shown below, some test scripts depend on this.
 
 Linux command line example:
 

--- a/stm32/README.cmake
+++ b/stm32/README.cmake
@@ -9,10 +9,13 @@ In addition, you must have a working gcc-arm-none-eabi toolchain installed (see 
 Out-of-source builds is enforced which prevents
 accidental pollution of the source repository.
 
-Make a build directory somewhere, ~/build/stm32 will be used in this example:
+Make a build directory somewhere, however, it
+is recommended to use the directory build_stm32 inside the stm32 
+directory as shown below
 
-  $ mkdir -p ~/build/stm32
-  $ cd ~/build/stm32
+  $ cd /path/to/codec2-dev/stm32
+  $ mkdir build_stm32
+  $ cd build_stm32
 
 
 The STM32 Standard Peripheral Library is required. The download`requires a registration on the STM website.

--- a/stm32/unittest/README_unittest.txt
+++ b/stm32/unittest/README_unittest.txt
@@ -2,6 +2,9 @@ README_unittest.txt
 Don Reid 2018/2019
 
 This is the unittest system for the stm32 implementation of codec2/FreeDV
+It is currently only working on linux systems. It requires a STM32F4xx processor 
+development board connected to/having a ST-LINK , e.g. 
+a STM32F4 Discovery board. 
 
 Objectives
 ==========
@@ -49,6 +52,14 @@ Debug and semihosting
 Building and Running the stm32 Unit Tests
 =========================================
 
+0/ Build codec2 for linux and stm32 
+
+   Run the linux cmake build using /path/to/codec2/build_linux 
+   as build directory, see instructions in the codec2 top level directory.
+
+   Run the stm32 cmake build using /path/to/codec2/stm32/build_stm32 
+   as build directory, see instructions in the stm32 directory.
+   
 1/ Build stlink:
 
   $ cd ~
@@ -71,32 +82,13 @@ Building and Running the stm32 Unit Tests
   2018-12-29T06:52:16 INFO common.c: SRAM size: 0x30000 bytes (192 KiB), Flash: 0x100000 bytes (1024 KiB) in pages of 16384 bytes
   2018-12-29T06:52:16 INFO gdb-server.c: Chip ID is 00000413, Core ID is  2ba01477.
   2018-12-29T06:52:16 INFO gdb-server.c: Listening at *:4242...
-
-2/ The STM32 Standard Preipheral Library is required and requires
-   registration to download. Save the zip file somewhere safe, then
-   extract to a directory of your choice, for example:
-
-   $ cd /periph/lib/path
-   $ unzip /path/to/en.stm32f4_dsp_stdperiph_lib.zip
-
-   The unittest Makefile requires a path to the unzipped Standard
-   Preipheral Library, this can be set by adding a local.mak file in
-   the codec2-dev/stm32/unittest directory:
-
-   $ cd ~/codec2-dev/stm32/unittest/src
-   $ echo 'PERIPHLIBDIR = /periph/lib/path/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0' > local.mak
-
-3/ Now we can build the unittests:
-
-   $ cd codec2-dev/stm32/unittest/src
-   $ make
   
-3/ To run a single test:
+2/ To run a single test set:
 
    $ cd codec2-dev/stm32/unittest/scripts
    $ ./run_all_ldpc_tests
 
-4/ To run ALL tests:
+3/ To run ALL tests:
 
    (TODO Don - pls add command to run all tests)
    


### PR DESCRIPTION
Added information regarding the recommended location / names of builds
for linux and stm32 builds.
Aligned build script in .travis.yml to follow recommendation