### PR TITLE
STM32 Unittesting performance fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
 - export STDLIBDIR=$HOME/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0
 - if [ ! "$STDLIBURL" == "" ]; then pwd; wget -q $STDLIBURL; 7z  x -p$STDLIBKEY -o$HOME
   stdperiph_lib.zip; fi
+- unset STDLIBURL STDLIBKEY # DO NOT TOUCH  
 script:
 - mkdir -p $BUILDSTD
 - cd $BUILDSTD
@@ -37,8 +38,13 @@ script:
   -DUT_PARAMS="--openocd" && make -j4 ) ; fi
 - if [ -n "$UT_SSH_PARAMS" ]; then  PATH="$GCC_DIR/bin/":${PATH} ctest -V -E ofdm_demod_ldpc_fade; fi
 before_install:
+# DO NOT TOUCH START
 - if [ -n "$UT_SSH_PARAMS" ]; then openssl aes-256-cbc -K $KEY_K -iv $KEY_IV
   -in stm32/unittest/lib/ut_travis.enc -out /tmp/ut_travis -d 
   && eval "$(ssh-agent -s)"
   && chmod 600 /tmp/ut_travis
-  && ssh-add /tmp/ut_travis >/dev/null 2>&1 && ssh -q $UT_SSH_PARAMS  uname -a ; fi
+  && ssh-add /tmp/ut_travis >/dev/null 2>&1 
+  && rm -f /tmp/ut_travis; 
+  fi
+- unset KEY_K KEY_IV 
+# DO NOT TOUCH END

--- a/stm32/stm32_flash.ld
+++ b/stm32/stm32_flash.ld
@@ -139,4 +139,13 @@ SECTIONS
     . = . + _Min_Stack_Size;
     . = ALIGN(4);
   } >RAM
+
+  .ccm (NOLOAD) : 
+  {
+ . = ALIGN(4);
+ _sccmram = .;
+ *(.ccm)
+ . = ALIGN(4);      
+	_eccmram = .;
+  } >CCM
 }

--- a/stm32/unittest/README_unittest.md
+++ b/stm32/unittest/README_unittest.md
@@ -59,6 +59,8 @@ the more likely people are to run it.
 These tests required a connection from the arm-none-eabi-gdb debugger to the
 stm32 hardware. For this we use a recent version of OpenOCD or alternatively 
 the st-util program.
+Running tests with the stm32 hardware  connected to a separate machine via ssh
+is possible. This works only with a patched (fixed) OpenOCD, see below.
 
 ### OpenOCD
 We recommend to use openocd instead of stlink. 
@@ -69,7 +71,7 @@ messages rearding SYS_FLEN not support (see openocd_stderr.log in the test_run
 directories), your openocd is too old. Make sure to have the right openocd
 first in the PATH if you have multiple openocd installed!
 
-It is recommended to build OpenOCD from sources, see below.
+It is strongly recommended to build OpenOCD from sources, see below.
 
 ### st-util
 Most distributions don't have stutil included. Easiest way is to build it from
@@ -123,13 +125,16 @@ as build directory, see instructions in the stm32 directory.
   2018-12-29T06:52:16 INFO common.c: Loading device parameters....
   2018-12-29T06:52:16 INFO common.c: Device connected is: F4 device, id 0x10016413
   2018-12-29T06:52:16 INFO common.c: SRAM size: 0x30000 bytes (192 KiB), Flash: 0x100000 bytes (1024 KiB) in pages of 16384 bytes
-  2018-12-29T06:52:16 INFO gdb-server.c: Chip ID is 00000413, Core ID is  2ba01477.
+  2018-12-29T06:52:16 INFO gdb-server.c: Chip ID is 00000413, Core ID is  2ba01477.G
   2018-12-29T06:52:16 INFO gdb-server.c: Listening at *:4242...
 ```
 
 ### Build OpenOCD (recommended over stlink):
 OpenOCD needs to be built from the source. If you have successfully build
 the linux codec2 binaries, everything required to build OpenOCD is already installed.
+
+If you want to use openocd remotely via SSH, you have to use currently the patched
+source from (https://github.com/db4ple/openocd.git) instead of the official repository.
 
 1.
     The executable is placed in /usr/local/bin ! Make sure to have no
@@ -232,6 +237,25 @@ On Ubuntu:
    ```
    
 6. To run ALL tests, see "Quickstart" above
+
+### Running the tests remotely
+If the stm32 hardware is connected on a different pc with linux, the tests can be run remotely.
+Test will run slower, roughly 3 times.
+
+1. You have to build OpenOCD on the remote machine with the STM32 board. It must be built from 
+   (https://github.com/db4ple/openocd.git). 
+2. You don't need OpenOCD installed on your build pc.
+3. You have to be able to run ssh with public key authentication using ssh-agent so that
+   you can ssh into the remote machine without entering a password. 
+4. You have to add UT_PARAMS=--openocd to the stm32 cmake call
+5. You have to call ctest with the proper UT_SSH_PARAMS settings, e.g.
+```
+UT_SSH_PARAMS="-p 22 -q remoteuser@remotemachine" ctest -V
+```
+
+
+
+
 
 
 # vi:set ts=3 et sts=3:

--- a/stm32/unittest/scripts/run_stm32_prog
+++ b/stm32/unittest/scripts/run_stm32_prog
@@ -21,9 +21,11 @@ for arg in "$@"; do
 if [ -z "$UT_SSH_PARAMS" ]; then
   UT_SSH=""
   UT_SLEEP=${UT_SLEEP:=1}
+  UI_SH_FIO="disable"
 else
   UT_SSH="ssh -f -L 3333:localhost:3333 $UT_SSH_PARAMS"
   UT_SLEEP=${UT_SLEEP:=4}
+  UT_SH_FIO="enable"
 fi
 
 if [ ${ARGS[--openocd]+_} ] ; then
@@ -42,7 +44,7 @@ if [ ${ARGS[--openocd]+_} ] ; then
         shell sleep ${UT_SLEEP}
 	target remote :3333
         monitor arm semihosting enable
-        monitor arm semihosting_fileio enable
+        monitor arm semihosting_fileio $UT_SH_FIO 
 	EEOOFF
     
        SHUTDOWN="monitor shutdown"
@@ -64,6 +66,7 @@ if [ ${ARGS[--load]+_} ] ; then
 
 cat <<-EEOOFF >> gdb_cmds
         monitor reset halt
+        monitor adapter_khz 4000
 	break EndofMain
 	break abort
 	EEOOFF

--- a/stm32/unittest/src/tst_ldpc_enc.c
+++ b/stm32/unittest/src/tst_ldpc_enc.c
@@ -39,6 +39,9 @@
 
 #include "HRA_112_112.h"
 
+static __attribute__ ((section (".ccm"))) char fin_buffer[8*8192];
+char fout_buffer[1024];
+
 int opt_exists(char *argv[], int argc, char opt[]) {
     int i;
     for (i=0; i<argc; i++) {
@@ -73,31 +76,32 @@ int main(int argc, char *argv[])
     ldpc.H_rows = (uint16_t *)HRA_112_112_H_rows;
     ldpc.H_cols = (uint16_t *)HRA_112_112_H_cols;
 
-    int sin = open("stm_in.raw", O_RDONLY);
-    if (sin < 0) {
+    FILE* fin = fopen("stm_in.raw", "rb");
+    if (fin == NULL) {
         printf("Error opening input file\n");
         exit(1);
     }
+    setvbuf(fin, fin_buffer,_IOFBF,sizeof(fin_buffer));
 
-    int sout = open("stm_out.raw", O_WRONLY|O_TRUNC|O_CREAT);
-    if (sout < 0) {
+    FILE* fout = fopen("stm_out.raw", "wb");
+    if (fout == NULL) {
         printf("Error opening output file\n");
         exit(1);
     }
 
-    while (read(sin, ibits, sizeof(char) * ldpc.NumberParityBits) == 
+    while (fread(ibits, sizeof(char) , ldpc.NumberParityBits, fin) == 
     		ldpc.NumberParityBits) {
 
         PROFILE_SAMPLE(ldpc_encode);
         encode(&ldpc, ibits, pbits);
         PROFILE_SAMPLE_AND_LOG2(ldpc_encode, "  ldpc_encode");
 
-        write(sout, ibits, sizeof(char) * ldpc.NumberRowsHcols);
-        write(sout, pbits, sizeof(char) * ldpc.NumberParityBits);
+        fwrite(ibits, sizeof(char) , ldpc.NumberRowsHcols, fout);
+        fwrite(pbits, sizeof(char) , ldpc.NumberParityBits, fout);
     }
 
-    close(sin);
-    close(sout);
+    fclose(fin);
+    fclose(fout);
     
     fflush(stdout);
     stdout = freopen("stm_profile", "w", stdout);


### PR DESCRIPTION
- After identifying the OpenOCD issue which broke buffered fread for us,
buffers help us to speed up testing significantly. We use CCM for
our I/O buffers so that the normal heap size for the application is not
reduced.
- We only use semihosting_fileio for OpenOCD if we are running remote
testing via ssh since it requires not yet mainstream openocd fixes.

Runtime for the STM32 test is about half of the time it took before these changes.
The results are identical.