### PR TITLE
Separate builds for sm1000 and sm1000_700D

### DIFF
--- a/stm32/CMakeLists.txt
+++ b/stm32/CMakeLists.txt
@@ -385,7 +385,14 @@ list(APPEND SM1000_SRCS ${CODEC2_SRCS})
 add_mapped_executable(sm1000 ${SM1000_SRCS} ${SYSTEM_SRCS})
 target_link_libraries(sm1000 stm32f4_adac stm32f4 CMSIS)
 target_compile_options(sm1000 PRIVATE "-O3")
+target_compile_definitions(sm1000 PRIVATE -UFREEDV_MODE_700D_EN -UCODEC2_MODE_700C_EN)
 elf2bin(sm1000)
+
+add_mapped_executable(sm1000_700D ${SM1000_SRCS} ${SYSTEM_SRCS})
+target_link_libraries(sm1000_700D stm32f4_adac stm32f4 CMSIS)
+target_compile_options(sm1000_700D PRIVATE "-O3")
+target_compile_definitions(sm1000_700D PRIVATE -UFREEDV_MODE_1600_EN -UCODEC2_MODE_1300_EN)
+elf2bin(sm1000_700D)
 
 set(FREEDV_TX_PROFILE_SRCS
 src/freedv_tx_profile.c


### PR DESCRIPTION
This should create a 1600 and a 700D build for the sm1000
However, it will break since in the 700D build the sm1000_main.c code will run freedv_open(FREEDV_MODE1600), which will not compile (due to lack of 1600 support in the sm1000_700D), need to add conditional setting of mode based on available mode. 
EDIT: Idea does not work, so I close this PR for now.