### PR TITLE
Reduced ofdm_get_max_samples_per_frame()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,7 +317,7 @@ if(UNITTEST)
     add_test(NAME test_OFDM_modem_octave_port_Nc_31
              COMMAND sh -c "NC=31 PATH_TO_TOFDM=${CMAKE_CURRENT_BINARY_DIR}/unittest/tofdm octave --no-gui -qf ${CMAKE_CURRENT_SOURCE_DIR}/octave/tofdm.m"
              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/octave)
-             set_tests_properties(test_OFDM_modem_octave_port PROPERTIES
+             set_tests_properties(test_OFDM_modem_octave_port_Nc_31 PROPERTIES
              PASS_REGULAR_EXPRESSION "fails: 0")
 
     add_test(NAME test_COHPSK_modem_AWGN_BER

--- a/octave/ofdm_lib.m
+++ b/octave/ofdm_lib.m
@@ -73,7 +73,8 @@ function [t_est timing_valid timing_mx av_level] = est_timing(states, rx, rate_f
     end
 
     [timing_mx t_est] = max(corr);
-    timing_valid = timing_mx > timing_mx_thresh;
+    % only declare timing valid if there are enough samples in rxbuf to demodulate a frame
+    timing_valid = (abs(rx(t_est)) > 0) && (timing_mx > timing_mx_thresh);
     
     if verbose > 1
       printf("  av_level: %5.4f mx: %4.3f timing_est: %4d timing_valid: %d\n", av_level, timing_mx, t_est, timing_valid);
@@ -483,7 +484,7 @@ function [timing_valid states] = ofdm_sync_search(states, rxbuf_in)
 
     % calculate number of samples we need on next buffer to get into sync
 
-    states.nin = Nsamperframe + ct_est - 1;
+    states.nin = ct_est - 1;
 
     % reset modem states
 

--- a/octave/ofdm_rx.m
+++ b/octave/ofdm_rx.m
@@ -99,9 +99,9 @@ function ofdm_rx(filename, mode="700D", error_pattern_filename)
     states = sync_state_machine(states, rx_uw);
 
     if states.verbose
-      printf("f: %2d state: %-10s uw_errors: %2d %1d Nerrs: %3d foff: %5.1f clkOff: %5.0f\n",
-             f, states.last_sync_state, states.uw_errors, states.sync_counter, Nerrs, states.foff_est_hz,
-             states.clock_offset_est*1E6);
+      printf("f: %2d nin: %4d state: %-10s uw_errors: %2d %1d pbw: %-4s Nerrs: %3d foff: %5.1f clkOff: %5.0f\n",
+             f, states.nin, states.last_sync_state, states.uw_errors, states.sync_counter, states.phase_est_bandwidth, Nerrs,
+             states.foff_est_hz, states.clock_offset_est*1E6);
     end
 
     % act on any events returned by state machine
@@ -132,6 +132,7 @@ function ofdm_rx(filename, mode="700D", error_pattern_filename)
   printf("Es/No est dB: % -4.1f SNR3k: %3.2f %f %f\n", EsNo_estdB, SNR_estdB, mean(sig_var_log), mean(noise_var_log));
   
   figure(1); clf; 
+  plot(rx_np_log,'+');
   plot(rx_np_log(floor(end/2):end),'+');
   mx = 2*max(abs(rx_np_log));
   axis([-mx mx -mx mx]);

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -687,8 +687,8 @@ static int est_timing(struct OFDM *ofdm, complex float *rx, int length,
         }
     }
 
-    *timing_valid = (*timing_mx > ofdm_timing_mx_thresh); /* bool but used as external int */
-
+    // only declare timing valid if there are enough samples in rxbuf to demodulate a frame
+    *timing_valid = (cabsf(rx[timing_est]) > 0.0) && (*timing_mx > ofdm_timing_mx_thresh); 
     if (ofdm->verbose > 2) {
         fprintf(stderr, "  av_level: %f  max: %f timing_est: %d timing_valid: %d\n", (double) av_level,
              (double) *timing_mx, timing_est, *timing_valid);
@@ -852,7 +852,7 @@ int ofdm_get_samples_per_frame() {
 }
 
 int ofdm_get_max_samples_per_frame() {
-    return 2 * ofdm_max_samplesperframe;
+    return ofdm_max_samplesperframe;
 }
 
 int ofdm_get_bits_per_frame() {
@@ -1038,7 +1038,7 @@ static int ofdm_sync_search_core(struct OFDM *ofdm) {
 
         /* calculate number of samples we need on next buffer to get into sync */
 
-        ofdm->nin = ofdm_samplesperframe + ct_est;
+        ofdm->nin = ct_est;
 
         /* reset modem states */
 

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -658,8 +658,8 @@ int main(int argc, char *argv[]) {
                 r = (ofdm->frame_count_interleaver - 1) % interleave_frames;
             }
 
-            fprintf(stderr, "%3d st: %-6s euw: %2d %1d f: %5.1f pbw: %d ist: %-6s %2d eraw: %3d ecdd: %3d iter: %3d pcc: %3d\n",
-                    f,
+            fprintf(stderr, "%3d nin: %4d st: %-6s euw: %2d %1d f: %5.1f pbw: %d ist: %-6s %2d eraw: %3d ecdd: %3d iter: %3d pcc: %3d\n",
+                    f, nin_frame, 
                     statemode[ofdm->last_sync_state],
                     ofdm->uw_errors,
                     ofdm->sync_counter,

--- a/unittest/ofdm_fade.sh
+++ b/unittest/ofdm_fade.sh
@@ -19,5 +19,5 @@ pwd
 # BER should be around 4% for this test (it's better for larger interleavers but no one uses interlaving in practice)
 ofdm_mod --in /dev/zero --ldpc 1 --testframes 60 --txbpf | cohpsk_ch - - -24 --Fs 8000 -f -10 --fast --raw_dir $RAW | ofdm_demod --out /dev/null --testframes --verbose 1 --ldpc 1 2> $results
 cber=$(cat $results | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
-python -c "import sys; sys.exit(0) if $cber<0.05 else sys.exit(1)"
+python -c "import sys; sys.exit(0) if $cber<=0.05 else sys.exit(1)"
 


### PR DESCRIPTION
While working on https://github.com/drowe67/codec2/pull/42 I re-discovered ofdm_get_max_samples_per_frame() is required to be two frames long.  This is because during acquisition, est_timing() will output coarse timing between 1 and 2 frames in the future, resulting on ```nin``` values between 1 and two frames in the future.  

For the stm32 his means we need buffers and DAC/ADC FIFOs at least 2 700D frames long, a lot of memory at Fs=16 kHz.

This PR is an attempt to reduce the memory required by reducing the coarse timing and ```nin``` range to 0 to 1 frame.