### PR TITLE
Fix memory leaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ dist: xenial
 addons:
   apt:
     packages: libc6-i386 octave-common octave gnuplot
-      sox p7zip-full python3-numpy octave-signal
+      sox p7zip-full python3-numpy octave-signal valgrind
 cache:
   directories:
   - "$HOME/$GCC_BASE"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,7 @@ if(UNITTEST)
              )
 
      add_test(NAME test_FreeDV_1600_tx_memory_leak
-             COMMAND sh -c " valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes $<TARGET_FILE:freedv_tx> 1600 ../../raw/hts1a.raw /dev/null"
+             COMMAND sh -c " valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./freedv_tx 1600 ../../raw/hts1a.raw /dev/null"
              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src
              )
              set_tests_properties(test_FreeDV_1600_tx_memory_leak PROPERTIES PASS_REGULAR_EXPRESSION "ERROR SUMMARY: 0 errors")
@@ -398,5 +398,18 @@ if(UNITTEST)
              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src
              )
              set_tests_properties(test_FreeDV_1600_rx_memory_leak PROPERTIES PASS_REGULAR_EXPRESSION "ERROR SUMMARY: 0 errors")
+
+     add_test(NAME test_FreeDV_700D_tx_memory_leak
+             COMMAND sh -c " valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./freedv_tx 700D ../../raw/hts1a.raw /dev/null"
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src
+             )
+             set_tests_properties(test_FreeDV_700D_tx_memory_leak PROPERTIES PASS_REGULAR_EXPRESSION "ERROR SUMMARY: 0 errors")
+
+     add_test(NAME test_FreeDV_700D_rx_memory_leak
+             COMMAND sh -c "./freedv_tx 1600 ../../raw/hts1a.raw t.raw; \
+                            valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./freedv_rx 700D t.raw /dev/null"
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src
+             )
+             set_tests_properties(test_FreeDV_700D_rx_memory_leak PROPERTIES PASS_REGULAR_EXPRESSION "ERROR SUMMARY: 0 errors")
 
 endif(UNITTEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,4 +386,17 @@ if(UNITTEST)
              COMMAND sh -c "dd bs=2560 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --interleave 8 --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --interleave 8 --testframes"
              )
 
+     add_test(NAME test_FreeDV_1600_tx_memory_leak
+             COMMAND sh -c " valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes $<TARGET_FILE:freedv_tx> 1600 ../../raw/hts1a.raw /dev/null"
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src
+             )
+             set_tests_properties(test_FreeDV_1600_tx_memory_leak PROPERTIES PASS_REGULAR_EXPRESSION "ERROR SUMMARY: 0 errors")
+
+     add_test(NAME test_FreeDV_1600_rx_memory_leak
+             COMMAND sh -c "./freedv_tx 1600 ../../raw/hts1a.raw t.raw; \
+                            valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes ./freedv_rx 1600 t.raw /dev/null"
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src
+             )
+             set_tests_properties(test_FreeDV_1600_rx_memory_leak PROPERTIES PASS_REGULAR_EXPRESSION "ERROR SUMMARY: 0 errors")
+
 endif(UNITTEST)

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -162,8 +162,8 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
         if (f->fdmdv_bits == NULL)
             return NULL;
         nbit = 2*fdmdv_bits_per_frame(f->fdmdv);
-        f->tx_bits = (int*)MALLOC(nbit*sizeof(int));
-        f->rx_bits = (int*)MALLOC(nbit*sizeof(int));
+        f->tx_bits = (int*)CALLOC(1, nbit*sizeof(int));
+        f->rx_bits = (int*)CALLOC(1, nbit*sizeof(int));
         if ((f->tx_bits == NULL) || (f->rx_bits == NULL)) {
             if (f->tx_bits != NULL) {
               FREE(f->tx_bits);
@@ -671,8 +671,11 @@ void freedv_close(struct freedv *freedv) {
     FREE(freedv->packed_codec_bits);
     FREE(freedv->codec_bits);
     FREE(freedv->tx_bits);
-    if (FDV_MODE_ACTIVE(FREEDV_MODE_1600, freedv->mode))
+    FREE(freedv->rx_bits);
+    if (FDV_MODE_ACTIVE(FREEDV_MODE_1600, freedv->mode)) {
+        FREE(freedv->fdmdv_bits);
         fdmdv_destroy(freedv->fdmdv);
+    }
     if (FDV_MODE_ACTIVE( FREEDV_MODE_700, freedv->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700B, freedv->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700C, freedv->mode))
         cohpsk_destroy(freedv->cohpsk);
     if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, freedv->mode)) {

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -137,6 +137,7 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
     f->frames = 0;
     f->speech_sample_rate = FS_VOICE_8K;
     f->stats.snr_est = 0.0;
+    f->tx_bits = f->rx_bits = NULL;
     
     /* -----------------------------------------------------------------------------------------------*\
     |                     Init states for this mode, and set up samples in/out                         |

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -497,6 +497,9 @@ void ofdm_destroy(struct OFDM *ofdm) {
     FREE(ofdm->rx_amp);
     FREE(ofdm->aphase_est_pilot_log);
     FREE(ofdm->tx_uw);
+    FREE(tx_uw_syms);
+    FREE(uw_ind);
+    FREE(uw_ind_sym);
     FREE(ofdm);
 }
 
@@ -896,7 +899,8 @@ void ofdm_set_off_est_hz(struct OFDM *ofdm, float val) {
 }
 
 void ofdm_set_tx_bpf(struct OFDM *ofdm, bool val) {
-    if (val == true) {
+    //fprintf(stderr, "ofdm_set_tx_bpf: val: %d\n", val);
+    if ((val == true) && (ofdm->ofdm_tx_bpf == NULL)) {
     	allocate_tx_bpf(ofdm);
     	ofdm->tx_bpf_en = true;
     } else {


### PR DESCRIPTION
While working on https://github.com/drowe67/codec2/pull/42 found some strange behaviour with the pointer to freedv states returned by freedv_open() when I do multiple successive freedv_open()/freedv_close() calls.

Have found memory leaks in both 700D and 1600, and fixing, and adding x86 ctests that call valgrind to trap any future issues.