### PR TITLE
Minor changes to remove double promotion warnings

### DIFF
--- a/src/cohpsk.c
+++ b/src/cohpsk.c
@@ -1113,18 +1113,22 @@ void cohpsk_demod(struct COHPSK *coh, float rx_bits[], int *sync_good, COMP rx_f
 
 int cohpsk_fs_offset(COMP out[], COMP in[], int n, float sample_rate_ppm)
 {
-    double tin, f;
-    int   tout, t1, t2;
+    double f;
+    double tin = 0.0;
+    double step = 1.0 + sample_rate_ppm/1E6;
+    int t1, t2;
+    int tout = 0;
 
-    tin = 0.0; tout = 0;
-    while (tin < n) {
-      t1 = floor(tin);
-      t2 = ceil(tin);
-      f = tin - t1;
-      out[tout].real = (1.0-f)*in[t1].real + f*in[t2].real;
-      out[tout].imag = (1.0-f)*in[t1].imag + f*in[t2].imag;
-      tout += 1;
-      tin  += 1.0 + sample_rate_ppm/1E6;
+    while (tin < (double) n) {
+      t1 = (int) floor(tin);
+      t2 = (int) ceil(tin);
+      f = tin - (double) t1;
+
+      out[tout].real = ((double)1.0-f)*(double)in[t1].real + f*(double)in[t2].real;
+      out[tout].imag = ((double)1.0-f)*(double)in[t1].imag + f*(double)in[t2].imag;
+
+      tin += step;
+      tout++;
       //printf("tin: %f tout: %d f: %f\n", tin, tout, f);
     }
 

--- a/unittest/tofdm.c
+++ b/unittest/tofdm.c
@@ -104,24 +104,23 @@ static int ofdm_nuwbits;            /* Unique word, used for positive indication
 static int fs_offset(COMP out[], COMP in[], int n, float sample_rate_ppm) {
     double f;
     double tin = 0.0;
+    double step = 1.0 + sample_rate_ppm/1E6;
     int t1, t2;
     int tout = 0;
 
     while (tin < (double) (n-1)) {
       t1 = (int) floor(tin);
       t2 = (int) ceil(tin);
-      assert(t2 < n);
+      f = tin - (double) t1;
 
-      f = (tin - (double) t1);
+      out[tout].real = ((double)1.0-f)*(double)in[t1].real + f*(double)in[t2].real;
+      out[tout].imag = ((double)1.0-f)*(double)in[t1].imag + f*(double)in[t2].imag;
 
-      out[tout].real = (1.0 - f) * in[t1].real + f * in[t2].real;
-      out[tout].imag = (1.0 - f) * in[t1].imag + f * in[t2].imag;
-
-      tout += 1;
-      tin  += 1.0 + sample_rate_ppm / 1E6;
+      tin += step;
+      tout++;
+      //printf("tin: %f tout: %d f: %f\n", tin, tout, f);
     }
-    //printf("n: %d tout: %d tin: %f\n", n, tout, tin);
-    
+
     return tout;
 }
 

--- a/unittest/tofdm.c
+++ b/unittest/tofdm.c
@@ -111,6 +111,7 @@ static int fs_offset(COMP out[], COMP in[], int n, float sample_rate_ppm) {
     while (tin < (double) (n-1)) {
       t1 = (int) floor(tin);
       t2 = (int) ceil(tin);
+      assert(t2 < n);
       f = tin - (double) t1;
 
       out[tout].real = ((double)1.0-f)*(double)in[t1].real + f*(double)in[t2].real;


### PR DESCRIPTION
These warning show up in stm32 build. tofdm.c has a slightly modified version of the algorithm in cohpsk.c.

These use double as the numbers are so small.