### PR TITLE
Fix log likelyhood.

### DIFF
--- a/src/mpdecode_core.c
+++ b/src/mpdecode_core.c
@@ -591,7 +591,7 @@ void sd_to_llr(float llr[], double sd[], int n) {
 
     estEsN0 = 1.0/(2.0L * estvar + 1E-3);
     for(i=0; i<n; i++)
-        llr[i] = 4.0L * estEsN0 * sd[i];
+        llr[i] = 4.0L * estEsN0 * sd[i] / mean;
 }
 
 


### PR DESCRIPTION
Fixes: b8a8f669dc "modified ldpc_noise ... and refactored LLR mapping ..."
	which removed a normalisation step.

This is not apparent in your unit testing because that is using normalised samples, but it can have an adverse impact on anyone using your code without normalising the samples before applying ldpc error correction.