### PR TITLE
Fix ASCII buffer size.

### DIFF
--- a/src/horus_api.c
+++ b/src/horus_api.c
@@ -445,7 +445,8 @@ int horus_get_max_ascii_out_len(struct horus *hstates) {
         return hstates->max_packet_len/10;     /* 7 bit ASCII, plus 3 sync bits */
     }
     if (hstates->mode == HORUS_MODE_BINARY) {
-        return HORUS_BINARY_NUM_PAYLOAD_BYTES;
+        return (HORUS_BINARY_NUM_PAYLOAD_BYTES*2+1);     /* Hexadecimal encoded */
+
     }
     assert(0); /* should never get here */
     return 0;


### PR DESCRIPTION
Horus Binary output is ASCII hexidecimal encoded.

This may be related to the issue that you had with OSX builds of horus_demod.