### PR TITLE
Reutilize auto mode for locked mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,11 @@ if(UNITTEST)
              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/unittest
              )
            
+    add_test(NAME test_OFDM_modem_phase_est_bw
+             COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/unittest/ofdm_phase_est_bw.sh
+             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/unittest
+             )
+           
     add_test(NAME test_OFDM_modem_time_sync
              COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/unittest/ofdm_time_sync.sh
              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/unittest

--- a/src/codec2.c
+++ b/src/codec2.c
@@ -2724,4 +2724,5 @@ void codec2_700c_post_filter(struct CODEC2 *codec2_state, int en) {
 
 void codec2_700c_eq(struct CODEC2 *codec2_state, int en) {
     codec2_state->eq_en = en;
+    codec2_state->se = 0.0; codec2_state->nse = 0;
 }

--- a/src/codec2_ofdm.h
+++ b/src/codec2_ofdm.h
@@ -49,10 +49,12 @@ extern "C" {
 #define UN_SYNC      0  /* Used with the ofdm_set_sync() */
 #define AUTO_SYNC    1
 #define MANUAL_SYNC  2
-    
-#define LOCK_HIGH_PHASE_EST 0
-#define LOW_PHASE_EST  1
-#define HIGH_PHASE_EST 2
+
+#define AUTO_PHASE_EST   0 
+#define LOCKED_PHASE_EST 1
+
+#define LOW_BW       0
+#define HIGH_BW      1
 
 struct OFDM_CONFIG;
 struct OFDM;

--- a/src/codec2_ofdm.h
+++ b/src/codec2_ofdm.h
@@ -81,6 +81,7 @@ int ofdm_get_samples_per_frame(void);
 int ofdm_get_max_samples_per_frame(void);
 int ofdm_get_bits_per_frame(void);
 void ofdm_get_demod_stats(struct OFDM *ofdm, struct MODEM_STATS *stats);
+int ofdm_get_phase_est_bandwidth_mode(struct OFDM *ofdm);
 
 /* option setters */
 
@@ -88,6 +89,7 @@ void ofdm_set_verbose(struct OFDM *, int);
 void ofdm_set_timing_enable(struct OFDM *, bool);
 void ofdm_set_foff_est_enable(struct OFDM *, bool);
 void ofdm_set_phase_est_enable(struct OFDM *, bool);
+void ofdm_set_phase_est_bandwidth_mode(struct OFDM *ofdm, int val);
 void ofdm_set_off_est_hz(struct OFDM *, float);
 void ofdm_set_sync(struct OFDM *, int);
 void ofdm_set_tx_bpf(struct OFDM *, bool);

--- a/src/codec2_ofdm.h
+++ b/src/codec2_ofdm.h
@@ -50,7 +50,7 @@ extern "C" {
 #define AUTO_SYNC    1
 #define MANUAL_SYNC  2
     
-#define AUTO_PHASE_EST 0
+#define LOCK_HIGH_PHASE_EST 0
 #define LOW_PHASE_EST  1
 #define HIGH_PHASE_EST 2
 

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -2841,6 +2841,12 @@ void freedv_set_tx_bpf(struct freedv *f, int val) {
     }
 }
 
+void freedv_set_phase_est_bandwidth_mode(struct freedv *f, int val) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2020, f->mode)) {
+        ofdm_set_phase_est_bandwidth_mode(f->ofdm, val);
+    }
+}
+
 
 void freedv_set_verbose(struct freedv *f, int verbosity) {
     f->verbose = verbosity;

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -2847,6 +2847,11 @@ void freedv_set_phase_est_bandwidth_mode(struct freedv *f, int val) {
     }
 }
 
+void freedv_set_eq(struct freedv *f, int val) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)) {
+        codec2_700c_eq(f->codec2, val);
+    }
+}
 
 void freedv_set_verbose(struct freedv *f, int verbosity) {
     f->verbose = verbosity;

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -2422,9 +2422,9 @@ static int freedv_comprx_2020(struct freedv *f, COMP demod_in[], int *valid) {
     ofdm_sync_state_machine(ofdm, rx_uw);
 
     if ((f->verbose && (ofdm->last_sync_state == search)) || (f->verbose == 2)) {
-        fprintf(stderr, "%3d st: %-6s euw: %2d %1d f: %5.1f ist: %-6s %2d eraw: %3d ecdd: %3d iter: %3d pcc: %3d vld: %d, nout: %4d\n",
+        fprintf(stderr, "%3d st: %-6s euw: %2d %1d f: %5.1f pbw: %d ist: %-6s %2d eraw: %3d ecdd: %3d iter: %3d pcc: %3d vld: %d, nout: %4d\n",
                 f->frames++, statemode[ofdm->last_sync_state], ofdm->uw_errors, ofdm->sync_counter, 
-		(double)ofdm->foff_est_hz,
+		(double)ofdm->foff_est_hz, ofdm->phase_est_bandwidth,
                 statemode[ofdm->last_sync_state_interleaver], ofdm->frame_count_interleaver,
                 Nerrs_raw, Nerrs_coded, iter, parityCheckCount, *valid, nout);
     }

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -422,7 +422,7 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
     }
 
     /* Malloc something to appease freedv_destroy */
-    f->codec_bits = MALLOC(1);
+    f->codec_bits = NULL;
 #endif
     
     if (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2400B, mode)) {

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -181,7 +181,8 @@ void freedv_set_sync                    (struct freedv *freedv, int sync_cmd);
 void freedv_set_verbose                 (struct freedv *freedv, int verbosity);
 void freedv_set_tx_bpf                  (struct freedv *freedv, int val);
 void freedv_set_ext_vco                 (struct freedv *f, int val);
-
+void freedv_set_phase_est_bandwidth_mode(struct freedv *f, int val);
+      
 // Get parameters -------------------------------------------------------------------------
 
 struct MODEM_STATS;

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -182,6 +182,7 @@ void freedv_set_verbose                 (struct freedv *freedv, int verbosity);
 void freedv_set_tx_bpf                  (struct freedv *freedv, int val);
 void freedv_set_ext_vco                 (struct freedv *f, int val);
 void freedv_set_phase_est_bandwidth_mode(struct freedv *f, int val);
+void freedv_set_eq                      (struct freedv *f, int val);
       
 // Get parameters -------------------------------------------------------------------------
 

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -84,7 +84,7 @@ static const int8_t pilotvalues[] = {
    1, 1, 1, 1,-1, 1,-1, 1
 };
 
-/* static variables */
+/* static variables - used as storage for constants that are unchanged after init-time */
 
 static struct OFDM_CONFIG ofdm_config;
 
@@ -116,7 +116,6 @@ static int ofdm_bps; 	/* Bits per symbol */
 static int ofdm_m; 	/* duration of each symbol in samples */
 static int ofdm_ncp; 	/* duration of CP in samples */
 
-static int ofdm_phase_est_bandwidth_mode; /* Auto 0 or Locked 1 */
 static int ofdm_ftwindowwidth;
 static int ofdm_bitsperframe;
 static int ofdm_rowsperframe;
@@ -193,7 +192,6 @@ struct OFDM *ofdm_create(const struct OFDM_CONFIG *config) {
         ofdm_ntxtbits = 4;
         ofdm_ftwindowwidth = 11;
         ofdm_timing_mx_thresh = 0.30f;
-        ofdm_phase_est_bandwidth_mode = AUTO_PHASE_EST;
     } else {
         /* Use the users values */
 
@@ -212,12 +210,6 @@ struct OFDM *ofdm_create(const struct OFDM_CONFIG *config) {
         ofdm_rx_centre = config->rx_centre; /* RX Centre Audio Frequency */
         ofdm_fs = config->fs; /* Sample Frequency */
         ofdm_ntxtbits = config->txtbits;
-
-        if ((config->phase_est_bandwidth_mode != AUTO_PHASE_EST) && (config->phase_est_bandwidth_mode != LOCKED_PHASE_EST)) {
-            ofdm_phase_est_bandwidth_mode = AUTO_PHASE_EST;   /* pick auto */
-        } else {
-            ofdm_phase_est_bandwidth_mode = config->phase_est_bandwidth_mode;
-        }
 
         ofdm_ftwindowwidth = config->ftwindowwidth;
         ofdm_timing_mx_thresh = config->ofdm_timing_mx_thresh;
@@ -353,6 +345,7 @@ struct OFDM *ofdm_create(const struct OFDM_CONFIG *config) {
     ofdm->foff_est_en = true;
     ofdm->phase_est_en = true;
     ofdm->phase_est_bandwidth = high_bw;
+    ofdm->phase_est_bandwidth_mode = AUTO_PHASE_EST;
 
     ofdm->foff_est_gain = 0.1f;
     ofdm->foff_est_hz = 0.0f;

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -869,7 +869,7 @@ int ofdm_get_phase_est_bandwidth_mode(struct OFDM *ofdm) {
     return ofdm->phase_est_bandwidth_mode;    /* int version of enum */
 }
 
-int ofdm_set_phase_est_bandwidth_mode(struct OFDM *ofdm, int val) {
+void ofdm_set_phase_est_bandwidth_mode(struct OFDM *ofdm, int val) {
     if (val == LOW_BW) {
         ofdm->phase_est_bandwidth_mode = low_bw;    /* int version of enum */
     } else if (val == HIGH_BW) {

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -1584,8 +1584,9 @@ void ofdm_sync_state_machine(struct OFDM *ofdm, uint8_t *rx_uw) {
                 /* change to low bandwidth, but more accurate phase estimation */
                 /* but only if not locked to high */
 
-                if (ofdm_phase_est_bandwidth_mode != LOCKED_PHASE_EST)
+                if (ofdm->phase_est_bandwidth_mode != LOCKED_PHASE_EST) {
                     ofdm->phase_est_bandwidth = low_bw;
+                }
             }
         }
 

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -1854,7 +1854,7 @@ void ofdm_print_info(struct OFDM *ofdm) {
         "manualsync"
     };
     char *phase_est_bandwidth_mode[] = {
-        "high_lock_bw",
+        "lock_high_bw",
         "low_bw",
         "high_bw"
     };

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -686,7 +686,7 @@ int main(int argc, char *argv[]) {
                     ofdm->uw_errors,
                     ofdm->sync_counter,
                     ofdm->foff_est_hz,
-                    ofdm->phase_est_bandwidth_mode,
+                    ofdm->phase_est_bandwidth,
                     statemode[ofdm->last_sync_state_interleaver],
                     ofdm->frame_count_interleaver,
                     Nerrs_raw[r], Nerrs_coded[r], iter[r], parityCheckCount[r]);

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -83,7 +83,7 @@ void opt_help() {
     fprintf(stderr, "  --ns           Nframes   Number of Symbol Frames (8 default)\n");
     fprintf(stderr, "  --tcp            Nsecs   Cyclic Prefix Duration (.002 default)\n");
     fprintf(stderr, "  --ts             Nsecs   Symbol Duration (.018 default)\n");
-    fprintf(stderr, "  --bandwidth      [0|1]   Select bw mode AUTO low or high (0) or LOCKED high (1) (default 0)\n");
+    fprintf(stderr, "  --bandwidth      [0|1]   Select phase est bw mode AUTO low or high (0) or LOCKED high (1) (default 0)\n");
     fprintf(stderr, "  --interleave     depth   Interleaver for LDPC frames, e.g. 1,2,4,8,16 (default is 1)\n");
     fprintf(stderr, "                           Must also specify --ldpc option\n");
     fprintf(stderr, "  --tx_freq         freq   Set modulation TX centre Frequency (1500.0 default)\n");
@@ -130,7 +130,7 @@ int main(int argc, char *argv[]) {
     int nc = 17;
     int ns = 8;
     int verbose = 0;
-    int phase_est_bandwidth = AUTO_PHASE_EST;
+    int phase_est_bandwidth_mode = AUTO_PHASE_EST;
     int ldpc_en = 0;
     int data_bits_per_frame = 0;
 
@@ -238,7 +238,7 @@ int main(int argc, char *argv[]) {
                 ns = atoi(options.optarg);
                 break;
             case 'o':
-                phase_est_bandwidth = atoi(options.optarg);
+                phase_est_bandwidth_mode = atoi(options.optarg);
                 break;
             case 'p':
                 data_bits_per_frame = atoi(options.optarg);
@@ -310,10 +310,10 @@ int main(int argc, char *argv[]) {
     ofdm_config->fs = FS; /* Sample Frequency */
     ofdm_config->txtbits = 4; /* number of auxiliary data bits */
 
-    if ((phase_est_bandwidth <= 1) && (phase_est_bandwidth >= 0)) {
-        ofdm_config->phase_est_bandwidth = phase_est_bandwidth;
+    if ((phase_est_bandwidth_mode <= 1) && (phase_est_bandwidth_mode >= 0)) {
+        ofdm_config->phase_est_bandwidth_mode = phase_est_bandwidth_mode;
     } else {
-        ofdm_config->phase_est_bandwidth = AUTO_PHASE_EST;
+        ofdm_config->phase_est_bandwidth_mode = AUTO_PHASE_EST;
     }
 
     ofdm_config->ftwindowwidth = 11;
@@ -399,7 +399,7 @@ int main(int argc, char *argv[]) {
         
         fprintf(stderr, "Phase Estimate Switching: ");
 
-        switch (phase_est_bandwidth) {
+        switch (phase_est_bandwidth_mode) {
         case 0: fprintf(stderr, "Auto\n");
                 break;
         case 1: fprintf(stderr, "Locked\n");

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -310,12 +310,6 @@ int main(int argc, char *argv[]) {
     ofdm_config->fs = FS; /* Sample Frequency */
     ofdm_config->txtbits = 4; /* number of auxiliary data bits */
 
-    if ((phase_est_bandwidth_mode <= 1) && (phase_est_bandwidth_mode >= 0)) {
-        ofdm_config->phase_est_bandwidth_mode = phase_est_bandwidth_mode;
-    } else {
-        ofdm_config->phase_est_bandwidth_mode = AUTO_PHASE_EST;
-    }
-
     ofdm_config->ftwindowwidth = 11;
     ofdm_config->ofdm_timing_mx_thresh = 0.30f;
 
@@ -324,6 +318,8 @@ int main(int argc, char *argv[]) {
 
     free(ofdm_config);
 
+    ofdm_set_phase_est_bandwidth_mode(ofdm, phase_est_bandwidth_mode);
+    
     /* Get a copy of the actual modem config */
     ofdm_config = ofdm_get_config_param();
 

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -83,7 +83,7 @@ void opt_help() {
     fprintf(stderr, "  --ns           Nframes   Number of Symbol Frames (8 default)\n");
     fprintf(stderr, "  --tcp            Nsecs   Cyclic Prefix Duration (.002 default)\n");
     fprintf(stderr, "  --ts             Nsecs   Symbol Duration (.018 default)\n");
-    fprintf(stderr, "  --bandwidth    [0|1|2]   Select Auto Phase Estimate (0) Low (1) High (2) RX mode (default 2)\n");
+    fprintf(stderr, "  --bandwidth    [0|1|2]   Select Lock High Phase Estimate (0) Low (1) High (2) RX mode (default 2)\n");
     fprintf(stderr, "  --interleave     depth   Interleaver for LDPC frames, e.g. 1,2,4,8,16 (default is 1)\n");
     fprintf(stderr, "                           Must also specify --ldpc option\n");
     fprintf(stderr, "  --tx_freq         freq   Set modulation TX centre Frequency (1500.0 default)\n");
@@ -400,7 +400,7 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Phase Estimate Mode: ");
 
         switch (phase_est_bandwidth) {
-        case 0: fprintf(stderr, "Auto\n");
+        case 0: fprintf(stderr, "High Locked\n");
                 break;
         case 1: fprintf(stderr, "Low\n");
                 break;

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -83,7 +83,7 @@ void opt_help() {
     fprintf(stderr, "  --ns           Nframes   Number of Symbol Frames (8 default)\n");
     fprintf(stderr, "  --tcp            Nsecs   Cyclic Prefix Duration (.002 default)\n");
     fprintf(stderr, "  --ts             Nsecs   Symbol Duration (.018 default)\n");
-    fprintf(stderr, "  --bandwidth    [0|1|2]   Select Lock High Phase Estimate (0) Low (1) High (2) RX mode (default 2)\n");
+    fprintf(stderr, "  --bandwidth      [0|1]   Select bw mode AUTO low or high (0) or LOCKED high (1) (default 0)\n");
     fprintf(stderr, "  --interleave     depth   Interleaver for LDPC frames, e.g. 1,2,4,8,16 (default is 1)\n");
     fprintf(stderr, "                           Must also specify --ldpc option\n");
     fprintf(stderr, "  --tx_freq         freq   Set modulation TX centre Frequency (1500.0 default)\n");
@@ -130,7 +130,7 @@ int main(int argc, char *argv[]) {
     int nc = 17;
     int ns = 8;
     int verbose = 0;
-    int phase_est_bandwidth = HIGH_PHASE_EST;
+    int phase_est_bandwidth = AUTO_PHASE_EST;
     int ldpc_en = 0;
     int data_bits_per_frame = 0;
 
@@ -310,10 +310,10 @@ int main(int argc, char *argv[]) {
     ofdm_config->fs = FS; /* Sample Frequency */
     ofdm_config->txtbits = 4; /* number of auxiliary data bits */
 
-    if ((phase_est_bandwidth <= 2) && (phase_est_bandwidth >= 0)) {
+    if ((phase_est_bandwidth <= 1) && (phase_est_bandwidth >= 0)) {
         ofdm_config->phase_est_bandwidth = phase_est_bandwidth;
     } else {
-        ofdm_config->phase_est_bandwidth = HIGH_PHASE_EST;
+        ofdm_config->phase_est_bandwidth = AUTO_PHASE_EST;
     }
 
     ofdm_config->ftwindowwidth = 11;
@@ -397,14 +397,12 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "interleave_frames: %d\n", interleave_frames);
         ofdm_set_verbose(ofdm, verbose);
         
-        fprintf(stderr, "Phase Estimate Mode: ");
+        fprintf(stderr, "Phase Estimate Switching: ");
 
         switch (phase_est_bandwidth) {
-        case 0: fprintf(stderr, "High Locked\n");
+        case 0: fprintf(stderr, "Auto\n");
                 break;
-        case 1: fprintf(stderr, "Low\n");
-                break;
-        case 2: fprintf(stderr, "High\n");
+        case 1: fprintf(stderr, "Locked\n");
         }
     }
 
@@ -688,7 +686,7 @@ int main(int argc, char *argv[]) {
                     ofdm->uw_errors,
                     ofdm->sync_counter,
                     ofdm->foff_est_hz,
-                    ofdm->phase_est_bandwidth,
+                    ofdm->phase_est_bandwidth_mode,
                     statemode[ofdm->last_sync_state_interleaver],
                     ofdm->frame_count_interleaver,
                     Nerrs_raw[r], Nerrs_coded[r], iter[r], parityCheckCount[r]);

--- a/src/ofdm_internal.h
+++ b/src/ofdm_internal.h
@@ -66,7 +66,6 @@ typedef enum {
 /* phase estimator bandwidth options */
 
 typedef enum {
-    lock_high_bw,       /* lock wide track */
     low_bw,             /* can only track a narrow freq offset, but accurate         */
     high_bw             /* can track wider freq offset, but less accurate at low SNR */
 } PhaseEstBandwidth;
@@ -88,7 +87,8 @@ struct OFDM_CONFIG {
     int ns;  /* Number of Symbol frames */
     int bps;   /* Bits per Symbol */
     int txtbits; /* number of auxiliary data bits */
-    int phase_est_bandwidth; /* select low, high, or locked high phase est bandwidth, rather than letting state machine decide */
+    int phase_est_bandwidth; /* select auto or locked high phase est bandwidth */
+    int phase_est_bandwidth_mode; /* low 0 or high 1 bw */
     int ftwindowwidth;
 };
 
@@ -118,8 +118,10 @@ struct OFDM {
     Sync sync_mode;
 
     // Phase enums
-    PhaseEstBandwidth phase_est_bandwidth;
-    
+    PhaseEstBandwidth phase_est_bandwidth_mode;
+
+    int phase_est_bandwidth;
+
     // Complex
     complex float foff_metric;
      

--- a/src/ofdm_internal.h
+++ b/src/ofdm_internal.h
@@ -118,9 +118,9 @@ struct OFDM {
     Sync sync_mode;
 
     // Phase enums
-    PhaseEstBandwidth phase_est_bandwidth_mode;
+    PhaseEstBandwidth phase_est_bandwidth;
 
-    int phase_est_bandwidth;
+    int phase_est_bandwidth_mode;
 
     // Complex
     complex float foff_metric;

--- a/src/ofdm_internal.h
+++ b/src/ofdm_internal.h
@@ -66,7 +66,7 @@ typedef enum {
 /* phase estimator bandwidth options */
 
 typedef enum {
-    auto_bw,            /* future mode */
+    lock_high_bw,       /* lock wide track */
     low_bw,             /* can only track a narrow freq offset, but accurate         */
     high_bw             /* can track wider freq offset, but less accurate at low SNR */
 } PhaseEstBandwidth;
@@ -88,7 +88,7 @@ struct OFDM_CONFIG {
     int ns;  /* Number of Symbol frames */
     int bps;   /* Bits per Symbol */
     int txtbits; /* number of auxiliary data bits */
-    int phase_est_bandwidth; /* force low of high phase est bandwidth, rather than letting state machine decide */
+    int phase_est_bandwidth; /* select low, high, or locked high phase est bandwidth, rather than letting state machine decide */
     int ftwindowwidth;
 };
 

--- a/src/ofdm_internal.h
+++ b/src/ofdm_internal.h
@@ -71,7 +71,8 @@ typedef enum {
 } PhaseEstBandwidth;
 
 /*
- * Contains user configuration for OFDM modem
+ * User-defined configuration for OFDM modem.  Used to set up
+ * constants at init time, e.g. for different bit rate modems.
  */
 
 struct OFDM_CONFIG {
@@ -87,8 +88,6 @@ struct OFDM_CONFIG {
     int ns;  /* Number of Symbol frames */
     int bps;   /* Bits per Symbol */
     int txtbits; /* number of auxiliary data bits */
-    int phase_est_bandwidth; /* select auto or locked high phase est bandwidth */
-    int phase_est_bandwidth_mode; /* low 0 or high 1 bw */
     int ftwindowwidth;
 };
 

--- a/unittest/ofdm_fade.sh
+++ b/unittest/ofdm_fade.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 # 
 # David June 2019
-# Tests ofdm modem fading channel performance, using a sinulated channel
+# Tests 700D OFDM modem fading channel performance, using a sinulated channel
 
 PATH=$PATH:../build_linux/src
 RAW=$PWD/../raw

--- a/unittest/ofdm_phase_est_bw.sh
+++ b/unittest/ofdm_phase_est_bw.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -x
+#
+# ofdm_phase_est_bw.sh
+# David August 2019
+
+# Tests 2020 OFDM modem phase est bandwidth mode option. Locking the
+# phase est bandwidth to "high" is useful for High SNR channels with
+# fast fading or high phase noise.  In this test we show that with
+# high bandwidth phase est mode, the BER is < 5% for the "--faster" (2
+# Hz fading) channel model on a fairly high SNR channel.
+
+PATH=$PATH:../build_linux/src
+RAW=$PWD/../raw
+results=$(mktemp)
+
+# generate fading file
+if [ ! -f ../raw/faster_fading_samples.float ]; then
+    echo "Generating fading file ......"
+    cmd='cd ../octave; pkg load signal; cohpsk_ch_fading("../raw/faster_fading_samples.float", 8000, 2.0, 8000*60)'
+    octave --no-gui -qf --eval "$cmd"
+    [ ! $? -eq 0 ] && { echo "octave failed to run correctly .... exiting"; exit 1; }
+fi
+
+pwd
+# BER should be < 5% for this test
+nc=37; ofdm_mod --in /dev/zero --testframes 300 --nc $nc --ldpc 2 --verbose 0 | cohpsk_ch - - -40 --Fs 8000 -f 10 --ssbfilt 1 --faster --raw_dir $RAW | ofdm_demod --out /dev/null --testframes --nc $nc --verbose 1 --ldpc 2 --bandwidth 1 2> $results
+cat $results
+cber=$(cat $results | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
+python -c "import sys; sys.exit(0) if $cber<=0.05 else sys.exit(1)"
+


### PR DESCRIPTION
A new phase estimate mode called "lock_high_bw" was created in place of the unused auto mode. This mode will not ever switch to low_bw unless manually changed to high or low options.

Also changed ofdm_demod.

Did not change freedv_rx yet as it doesn't seem to deal with phase_bw at the moment, so will need some new algorithms.