### PR TITLE
Fix compile errors on OSX/LLVM due to stricter requirements for extern.

### DIFF
--- a/src/codec2_ofdm.h
+++ b/src/codec2_ofdm.h
@@ -28,10 +28,6 @@
 #ifndef CODEC2_OFDM_H
 #define CODEC2_OFDM_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* Includes */
     
 #include <complex.h>
@@ -42,6 +38,10 @@ extern "C" {
 #include "modem_stats.h"
 
 /* Defines */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define OFDM_AMP_SCALE (2E5*1.1491/1.06)   /* use to scale to 16 bit short */
 #define OFDM_CLIP (32767*0.35)             /* experimentally derived constant to reduce PAPR to about 8dB */

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -28,10 +28,6 @@
   along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef __cplusplus
-  extern "C" {
-#endif
-
 #ifndef __FREEDV_API__
 #define __FREEDV_API__
 
@@ -40,6 +36,10 @@
 
 #include "comp.h"
 #include "codec2_ofdm.h"
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
 
 #define FREEDV_MODE_1600        0
 #define FREEDV_MODE_700         1

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -31,14 +31,13 @@ target_link_libraries(ofdm_mem m)
 
 add_library(function_trace STATIC ../unittest/function_trace.c)
 
-if (NOT APPLE) 
 add_executable(ofdm_stack ofdm_stack.c ../src/ofdm.c ../src/octave.c ../src/kiss_fft.c ../src/modem_probe.c ../src/mpdecode_core.c ../src/phi0.c ../src/filter.c)
 if (CMAKE_C_COMPILER MATCHES "gcc$")
+    target_link_libraries(ofdm_stack function_trace m -no-pie "-Wl,-Map=ofdm_stack.map")
     target_compile_options(ofdm_stack PUBLIC -fstack-usage -finstrument-functions -no-pie)
 else()
+    target_link_libraries(ofdm_stack function_trace m -no-pie)
     target_compile_options(ofdm_stack PUBLIC -finstrument-functions -no-pie)
-endif()
-target_link_libraries(ofdm_stack function_trace m -no-pie "-Wl,-Map=ofdm_stack.map")
 endif()
 add_definitions(-D__UNITTEST__)
 

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(ofdm_mem m)
 
 add_library(function_trace STATIC ../unittest/function_trace.c)
 
+if (NOT APPLE) 
 add_executable(ofdm_stack ofdm_stack.c ../src/ofdm.c ../src/octave.c ../src/kiss_fft.c ../src/modem_probe.c ../src/mpdecode_core.c ../src/phi0.c ../src/filter.c)
 if (CMAKE_C_COMPILER MATCHES "gcc$")
     target_compile_options(ofdm_stack PUBLIC -fstack-usage -finstrument-functions -no-pie)
@@ -38,6 +39,7 @@ else()
     target_compile_options(ofdm_stack PUBLIC -finstrument-functions -no-pie)
 endif()
 target_link_libraries(ofdm_stack function_trace m -no-pie "-Wl,-Map=ofdm_stack.map")
+endif()
 add_definitions(-D__UNITTEST__)
 
 add_executable(tnewamp1 tnewamp1.c ../src/quantise.c ../src/newamp1.c ../src/mbest.c ../src/kiss_fft.c ../src/sine.c ../src/nlp.c ../src/dump.c ../src/octave.c ${CODEBOOKS})


### PR DESCRIPTION
Because of where extern "C" is defined in various include files, FreeDV fails to build (complaining about "templates needing C++ linkage", among other issues). Moving extern "C" below #includes resolves those particular compiler errors on OSX when using LLVM.

In addition, ofdm_stack needs to be excluded from OSX builds on my 10.14 machine. I'm not sure if that's needed long-term or not.