### PR TITLE
Differential PSK option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,11 @@ if(UNITTEST)
              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/unittest
              )
            
+    add_test(NAME test_OFDM_modem_fading_DPSK_BER
+             COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/unittest/ofdm_fade_dpsk.sh
+             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/unittest
+             )
+           
     add_test(NAME test_horus_binary
              COMMAND sh -c "sox ${CMAKE_CURRENT_SOURCE_DIR}/wav/horus_binary_ebno_4.5db.wav -r 48000 -t raw - | $<TARGET_FILE:horus_demod> -m binary - -"
              )

--- a/README_ofdm.txt
+++ b/README_ofdm.txt
@@ -182,7 +182,7 @@ Here are some useful tests for the LDPC coded C version of the modem, useful to 
 
 1/ AWGN channel, -2dB:
 
-./ofdm_mod --in /dev/zero --ldpc --testframes 60 --txbpf | ./cohpsk_ch - - -20 --Fs 8000 -f -10 | ./ofdm_demod --out /dev/null --testframes --verbose 1 --ldpc 1
+./ofdm_mod --in /dev/zero --ldpc 1 --testframes 60 --txbpf | ./cohpsk_ch - - -20 --Fs 8000 -f -10 | ./ofdm_demod --out /dev/null --testframes --verbose 1 --ldpc 1
 
 SVN Rev 3671:
   SNR3k(dB): -1.85 C/No: 32.9 PAPR:  9.8

--- a/src/codec2_ofdm.h
+++ b/src/codec2_ofdm.h
@@ -93,7 +93,8 @@ void ofdm_set_phase_est_bandwidth_mode(struct OFDM *ofdm, int val);
 void ofdm_set_off_est_hz(struct OFDM *, float);
 void ofdm_set_sync(struct OFDM *, int);
 void ofdm_set_tx_bpf(struct OFDM *, bool);
-
+void ofdm_set_dpsk(struct OFDM *ofdm, bool val);
+    
 void ofdm_print_info(struct OFDM *);
 
 #ifdef __cplusplus

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -2841,6 +2841,14 @@ void freedv_set_tx_bpf(struct freedv *f, int val) {
     }
 }
 
+/* DPSK option for OFDM modem, useful for high SNR, fast fading */
+
+void freedv_set_dpsk(struct freedv *f, int val) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2020, f->mode)) {
+        ofdm_set_dpsk(f->ofdm, val);
+    }
+}
+
 void freedv_set_phase_est_bandwidth_mode(struct freedv *f, int val) {
     if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2020, f->mode)) {
         ofdm_set_phase_est_bandwidth_mode(f->ofdm, val);

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -180,7 +180,7 @@ void freedv_set_carrier_ampl            (struct freedv *freedv, int c, float amp
 void freedv_set_sync                    (struct freedv *freedv, int sync_cmd);
 void freedv_set_verbose                 (struct freedv *freedv, int verbosity);
 void freedv_set_tx_bpf                  (struct freedv *freedv, int val);
-void freedv_set_tx_dpsk                 (struct freedv *freedv, int val);
+void freedv_set_dpsk                    (struct freedv *freedv, int val);
 void freedv_set_ext_vco                 (struct freedv *f, int val);
 void freedv_set_phase_est_bandwidth_mode(struct freedv *f, int val);
 void freedv_set_eq                      (struct freedv *f, int val);

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -180,6 +180,7 @@ void freedv_set_carrier_ampl            (struct freedv *freedv, int c, float amp
 void freedv_set_sync                    (struct freedv *freedv, int sync_cmd);
 void freedv_set_verbose                 (struct freedv *freedv, int verbosity);
 void freedv_set_tx_bpf                  (struct freedv *freedv, int val);
+void freedv_set_tx_dpsk                 (struct freedv *freedv, int val);
 void freedv_set_ext_vco                 (struct freedv *f, int val);
 void freedv_set_phase_est_bandwidth_mode(struct freedv *f, int val);
 void freedv_set_eq                      (struct freedv *f, int val);

--- a/src/freedv_rx.c
+++ b/src/freedv_rx.c
@@ -95,7 +95,7 @@ int main(int argc, char *argv[]) {
     int                        sync;
     float                      snr_est;
     float                      clock_offset;
-    int                        use_codecrx, use_testframes, interleave_frames, verbose, discard, use_complex;
+    int                        use_codecrx, use_testframes, interleave_frames, verbose, discard, use_complex, use_dpsk;
     struct CODEC2             *c2 = NULL;
     int                        i;
 
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
         sprintf(f2020,"|2020");
         #endif     
 	printf("usage: %s 1600|700|700B|700C|700D|2400A|2400B|800XA%s InputModemSpeechFile OutputSpeechRawFile\n"
-               " [--testframes] [--interleaver depth] [--codecrx] [-v] [--discard] [--usecomplex]\n", argv[0],f2020);
+               " [--testframes] [--interleaver depth] [--codecrx] [-v] [--discard] [--usecomplex] [--dpsk]\n", argv[0],f2020);
 	printf("e.g    %s 1600 hts1a_fdmdv.raw hts1a_out.raw\n", argv[0]);
 	exit(1);
     }
@@ -148,7 +148,7 @@ int main(int argc, char *argv[]) {
 	exit(1);
     }
 
-    use_codecrx = 0; use_testframes = 0; interleave_frames = 1; verbose = 0; discard = 0; use_complex = 0;
+    use_codecrx = 0; use_testframes = 0; interleave_frames = 1; verbose = 0; discard = 0; use_complex = 0; use_dpsk = 0;
 
     if (argc > 4) {
         for (i = 4; i < argc; i++) {
@@ -189,6 +189,9 @@ int main(int argc, char *argv[]) {
                 fprintf(stderr, "using complex!\n");
                 use_complex = 1;
             }
+            if (strcmp(argv[i], "--dpsk") == 0) {
+                use_dpsk = 1;
+            }
         }
     }
 
@@ -207,6 +210,7 @@ int main(int argc, char *argv[]) {
 
     freedv_set_snr_squelch_thresh(freedv, -100.0);
     freedv_set_squelch_en(freedv, 0);
+    freedv_set_dpsk(freedv, use_dpsk);
 
     short speech_out[freedv_get_n_speech_samples(freedv)];
     short demod_in[freedv_get_n_max_modem_samples(freedv)];
@@ -304,7 +308,7 @@ int main(int argc, char *argv[]) {
         float uncoded_ber = (float)Terrs/Tbits;
         fprintf(stderr, "BER......: %5.4f Tbits: %5d Terrs: %5d\n", 
 		(double)uncoded_ber, Tbits, Terrs);
-        if (mode == FREEDV_MODE_700D) {
+        if ((mode == FREEDV_MODE_700D) || (mode == FREEDV_MODE_2020)) {
             int Tbits_coded = freedv_get_total_bits_coded(freedv);
             int Terrs_coded = freedv_get_total_bit_errors_coded(freedv);
             float coded_ber = (float)Terrs_coded/Tbits_coded;

--- a/src/freedv_tx.c
+++ b/src/freedv_tx.c
@@ -96,7 +96,7 @@ int main(int argc, char *argv[]) {
     int                       n_speech_samples;
     int                       n_nom_modem_samples;
     int                       use_codectx, use_datatx, use_testframes, interleave_frames, use_clip, use_txbpf;
-    int                       use_ext_vco;
+    int                       use_ext_vco, use_dpsk;
     struct CODEC2             *c2;
     int                       i;
 
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
         sprintf(f2020,"|2020");
         #endif     
         printf("usage: %s 1600|700|700B|700C|700D|2400A|2400B|800XA%s InputRawSpeechFile OutputModemRawFile\n"
-               " [--testframes] [--interleave depth] [--codectx] [--datatx] [--clip 0|1] [--txbpf 0|1] [--extvco]\n", argv[0], f2020);
+               " [--testframes] [--interleave depth] [--codectx] [--datatx] [--clip 0|1] [--txbpf 0|1] [--extvco] [--dpsk]\n", argv[0], f2020);
         printf("e.g    %s 1600 hts1a.raw hts1a_fdmdv.raw\n", argv[0]);
         exit(1);
     }
@@ -151,7 +151,7 @@ int main(int argc, char *argv[]) {
     }
 
     use_codectx = 0; use_datatx = 0; use_testframes = 0; interleave_frames = 1; use_clip = 0; use_txbpf = 1;
-    use_ext_vco = 0;
+    use_ext_vco = 0; use_dpsk = 0;
     
     if (argc > 4) {
         for (i = 4; i < argc; i++) {
@@ -189,6 +189,9 @@ int main(int argc, char *argv[]) {
             if (strcmp(argv[i], "--extvco") == 0) {
                 use_ext_vco = 1;
             }
+            if (strcmp(argv[i], "--dpsk") == 0) {
+                use_dpsk = 1;
+            }
         }
     }
 
@@ -212,6 +215,7 @@ int main(int argc, char *argv[]) {
     freedv_set_squelch_en(freedv, 1);
     freedv_set_clip(freedv, use_clip);
     freedv_set_tx_bpf(freedv, use_txbpf);
+    freedv_set_dpsk(freedv, use_dpsk);
     freedv_set_ext_vco(freedv, use_ext_vco);
     freedv_set_verbose(freedv, 1);
     

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -1416,10 +1416,7 @@ static void ofdm_demod_core(struct OFDM *ofdm, int *rx_bits) {
             if (ofdm->phase_est_en == true) {
                 if (ofdm->dpsk) {
                     /* differential detection, using pilot as reference at start of frame */
-                    /* note cmplxconj() macro didn't work here */
-                    //rx_corr = ofdm->rx_sym[rr + 2][i] * cmplxconj(ofdm->rx_sym[rr + 1][i]);
-                    complex float c = crealf(ofdm->rx_sym[rr + 1][i]) - I*cimagf(ofdm->rx_sym[rr + 1][i]);
-                    rx_corr = ofdm->rx_sym[rr + 2][i] * c;
+                    rx_corr = ofdm->rx_sym[rr + 2][i] * cmplxconj(cargf(ofdm->rx_sym[rr + 1][i]));
                 }
                 else  {
                     /* regular coherent detection */

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -97,6 +97,7 @@ void opt_help() {
     fprintf(stderr, "  --start_secs      secs   Number of seconds delay before we start to demod\n");
     fprintf(stderr, "  --len_secs        secs   Number of seconds to run demod\n");
     fprintf(stderr, "  --skip_secs   timeSecs   At timeSecs introduce a large timing error by skipping half a frame of samples\n");
+    fprintf(stderr, "  --dpsk                   Differential PSK.\n");
     fprintf(stderr, "\n");
     
     exit(-1);
@@ -141,7 +142,8 @@ int main(int argc, char *argv[]) {
     bool log_active = false;
     bool ldpc_check = false;
     bool llr_en = false;
-
+    bool dpsk = false;
+    
     float tcp = 0.002f;
     float ts = 0.018f;
     float rx_centre = 1500.0f;
@@ -173,6 +175,7 @@ int main(int argc, char *argv[]) {
         {"start_secs", 'x', OPTPARSE_REQUIRED},        
         {"len_secs", 'y', OPTPARSE_REQUIRED},        
         {"skip_secs", 'z', OPTPARSE_REQUIRED},        
+        {"dpsk", 'q', OPTPARSE_NONE},        
         {0, 0, 0}
     };
 
@@ -242,6 +245,9 @@ int main(int argc, char *argv[]) {
                 break;
             case 'p':
                 data_bits_per_frame = atoi(options.optarg);
+                break;
+            case 'q':
+                dpsk = true;
                 break;
             case 'v':
                 verbose = atoi(options.optarg);
@@ -319,6 +325,7 @@ int main(int argc, char *argv[]) {
     free(ofdm_config);
 
     ofdm_set_phase_est_bandwidth_mode(ofdm, phase_est_bandwidth_mode);
+    ofdm_set_dpsk(ofdm, dpsk);
     
     /* Get a copy of the actual modem config */
     ofdm_config = ofdm_get_config_param();

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -386,7 +386,7 @@ int main(int argc, char *argv[]) {
         assert(data_bits_per_frame <= ldpc.ldpc_data_bits_per_frame);
         assert(coded_bits_per_frame <= ldpc.ldpc_coded_bits_per_frame);
         
-        if (verbose) {
+        if (verbose > 1) {
             fprintf(stderr, "ldpc_data_bits_per_frame = %d\n", ldpc.ldpc_data_bits_per_frame);
             fprintf(stderr, "ldpc_coded_bits_per_frame  = %d\n", ldpc.ldpc_coded_bits_per_frame);
             fprintf(stderr, "data_bits_per_frame = %d\n", data_bits_per_frame);

--- a/src/ofdm_internal.h
+++ b/src/ofdm_internal.h
@@ -153,6 +153,7 @@ struct OFDM {
     bool foff_est_en;
     bool phase_est_en;
     bool tx_bpf_en;
+    bool dpsk;
 };
 
 /* Prototypes */

--- a/src/ofdm_mod.c
+++ b/src/ofdm_mod.c
@@ -297,7 +297,7 @@ int main(int argc, char *argv[]) {
         assert(data_bits_per_frame <= ldpc.ldpc_data_bits_per_frame);
         assert(coded_bits_per_frame <= ldpc.ldpc_coded_bits_per_frame);
         
-        if (verbose) {
+        if (verbose > 1) {
             fprintf(stderr, "ldpc_data_bits_per_frame = %d\n", ldpc.ldpc_data_bits_per_frame);
             fprintf(stderr, "ldpc_coded_bits_per_frame  = %d\n", ldpc.ldpc_coded_bits_per_frame);
             fprintf(stderr, "data_bits_per_frame = %d\n", data_bits_per_frame);
@@ -352,7 +352,7 @@ int main(int argc, char *argv[]) {
     int nvaricode_bits = 0;
     int varicode_bit_index = 0;
 
-    if (verbose) {
+    if (verbose > 1) {
 	ofdm_print_info(ofdm);
     }
 

--- a/src/ofdm_mod.c
+++ b/src/ofdm_mod.c
@@ -71,6 +71,7 @@ void opt_help() {
     fprintf(stderr, "  -i --ldpc    [1|2]    Run LDPC decoder (1 -> (224,112) 700D code, 2 -> (504,396) 2020 code).\n"
                     "                        In testframe mode raw and coded errors will be counted.\n");
     fprintf(stderr, "  -p --databits numBits Number of data bits used in LDPC codeword.\n");
+    fprintf(stderr, "  --dpsk                Differential PSK.\n");
     fprintf(stderr, "\n");
     exit(-1);
 }
@@ -111,6 +112,7 @@ int main(int argc, char *argv[]) {
     int txbpf_en = 0;
     int testframes = 0;
     int use_text = 0;
+    int dpsk = 0;
 
     int Nframes = 0;
     int Nsec = 0;
@@ -142,6 +144,7 @@ int main(int argc, char *argv[]) {
         {"text", 'l', OPTPARSE_NONE},
         {"verbose", 'v', OPTPARSE_REQUIRED},
         {"databits", 'p', OPTPARSE_REQUIRED},        
+        {"dpsk", 'q', OPTPARSE_NONE},        
         {0, 0, 0}
     };
 
@@ -206,6 +209,9 @@ int main(int argc, char *argv[]) {
                 break;
             case 'p':
                 data_bits_per_frame = atoi(options.optarg);
+                break;
+            case 'q':
+                dpsk = 1;
                 break;
             case 'v':
                 verbose = atoi(options.optarg);
@@ -334,6 +340,9 @@ int main(int argc, char *argv[]) {
 
     if (txbpf_en) {
         ofdm_set_tx_bpf(ofdm, 1);
+    }
+    if (dpsk) {
+        ofdm_set_dpsk(ofdm, 1);
     }
 
     char text_str[] = "cq cq cq hello world\r"; // Add text bits to match other tests

--- a/unittest/ofdm_fade.sh
+++ b/unittest/ofdm_fade.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 # 
 # David June 2019
-# Tests 700D OFDM modem fading channel performance, using a sinulated channel
+# Tests 700D OFDM modem fading channel performance, using a simulated channel
 
 PATH=$PATH:../build_linux/src
 RAW=$PWD/../raw
@@ -16,7 +16,7 @@ if [ ! -f ../raw/fast_fading_samples.float ]; then
 fi
 
 pwd
-# BER should be around 4% for this test (it's better for larger interleavers but no one uses interlaving in practice)
+# BER should be around 4% for this test (it's better for larger interleavers but no one uses interleaving in practice)
 ofdm_mod --in /dev/zero --ldpc 1 --testframes 60 --txbpf | cohpsk_ch - - -24 --Fs 8000 -f -10 --fast --raw_dir $RAW | ofdm_demod --out /dev/null --testframes --verbose 2 --ldpc 1 2> $results
 cat $results
 cber=$(cat $results | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")

--- a/unittest/ofdm_fade_dpsk.sh
+++ b/unittest/ofdm_fade_dpsk.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -x
+# 
+# David Sep 2019
+# Tests 2020 OFDM modem fading channel performance in DPSK mode, using a simulated faster (2Hz) high SNR fading channel
+
+PATH=$PATH:../build_linux/src
+RAW=$PWD/../raw
+results=$(mktemp)
+
+# generate fading file
+if [ ! -f ../raw/faster_fading_samples.float ]; then
+    echo "Generating fading files ......"
+    cmd='cd ../octave; pkg load signal; cohpsk_ch_fading("../raw/faster_fading_samples.float", 8000, 2.0, 8000*60)'
+    octave --no-gui -qf --eval "$cmd"
+    [ ! $? -eq 0 ] && { echo "octave failed to run correctly .... exiting"; exit 1; }
+fi
+
+pwd
+# Coded BER should be < 1% for this test
+nc=31; ofdm_mod --in /dev/zero --testframes 300 --nc $nc --ldpc 2 --verbose 1 -p 312 --dpsk | cohpsk_ch - - -40 --Fs 8000 -f 10 --ssbfilt 1 --faster --raw_dir $RAW | ofdm_demod --out /dev/null --testframes --nc $nc --verbose 1 --ldpc 2 -p 312 --dpsk 2> $results
+cat $results
+cber=$(cat $results | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
+python -c "import sys; sys.exit(0) if $cber<=0.05 else sys.exit(1)"
+


### PR DESCRIPTION
Might be useful for channels with high SNR but rapid phase changes:

```
./ofdm_mod --in /dev/zero --ldpc 1 --testframes 6 --txbpf --dpsk | ./cohpsk_ch - - -100 --Fs 8000 -f -10 --fast | ./ofdm_demod --out /dev/null --testframes --verbose 1 --ldpc 1 --dpsk
```
This example with 2020 show's it hanging on with "faster" (2Hz Doppler bandwidth) fading:
```
nc=31; ./ofdm_mod --in /dev/zero --testframes 300 --nc $nc --ldpc 2 --verbose 1 -p 312 --dpsk | ./cohpsk_ch - - -40 --Fs 8000 -f 10 --ssbfilt 1 --faster | ./ofdm_demod --out /dev/null --testframes --nc $nc --verbose 1 --ldpc 2 -p 312 --dpsk
```
without --dpsk it falls over.

FreeDV API support, this hangs on quite nicely:
```
./freedv_tx 2020 ~/LPCNet/wav/all.wav - --testframes --dpsk | ./cohpsk_ch - - -40 --faster --Fs 8000 -f -40 | ./freedv_rx 2020 - - --testframes -v --dpsk > /dev/null
```
