### PR TITLE
Enable 450 bit/s mode on PC builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,17 @@ $ ./src/c2dec 700C hts1a_c2.bit hts1a_c2_700.raw
 ```
 $ play -t raw -r 8000 -e signed-integer -b 16 ./hts1a_c2_700.raw
 ```
-3/ Same thing with pipes:
+3/ If you prefer a one-liner without saving to files:
 ```
-$ ./src/c2enc 1300 ../raw/hts1a.raw - | ./src/c2dec 1300 - - | play -t raw -r 8000 -s -2 -
+$ ./src/c2enc 1300 ../raw/hts1a.raw - | ./src/c2dec 1300 - - | play -t raw -r 8000 -b 16 -e signed-integer -
+```
+   Same at 450 bit/s:
+```
+$ ./src/c2enc 450 ../raw/ve9qrp.raw - | ./src/c2dec 450 - - | play -t raw -r 8000 -e signed-integer -b 16 -
+```
+   Please note that 450PWB (pseudo-wideband) can be chosen for decoding, providing a bandwidth extension to 8kHz/16ksps from a 4kHz/8ksps encoded 450bit/s file:
+```
+$ ./src/c2enc 450 ../raw/ve9qrp.raw - | ./src/c2dec 450PWB - - | play -t raw -r 16000 -e signed-integer -b 16 -
 ```
 ## Programs
 

--- a/src/codec2.c
+++ b/src/codec2.c
@@ -114,7 +114,7 @@ struct CODEC2 * codec2_create(int mode)
     struct CODEC2 *c2;
     int            i,l;
 
-#ifndef CORTEX_M4
+#ifdef CORTEX_M4
     if (( CODEC2_MODE_ACTIVE(CODEC2_MODE_450, mode)) || 
         ( CODEC2_MODE_ACTIVE(CODEC2_MODE_450PWB, mode)) ) {
         return NULL;


### PR DESCRIPTION
The CORTEX-M4 macro should be inverted to enable the 450 mode on PC builds. On CORTEX-M4 the mode is still not included.
However, we ran the 450 mode on a Cortex-M4 successfully one year ago, but I currently don't have the insights if it is desired in the current form.