### PR TITLE
freedv_api.h: fix library #endif position

### DIFF
--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -211,9 +211,8 @@ int freedv_get_sz_error_pattern     (struct freedv *freedv);
 int freedv_get_protocol_bits        (struct freedv *freedv);
 int freedv_get_speech_sample_rate   (struct freedv *freedv);
 
-
-#endif
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif //__FREEDV_API__


### PR DESCRIPTION
fix position of the `#endif`