### PR TITLE
Remove a superfluous include

### DIFF
--- a/src/codec2_ofdm.h
+++ b/src/codec2_ofdm.h
@@ -30,7 +30,6 @@
 
 /* Includes */
     
-#include <complex.h>
 #include <stdbool.h>
 #include <stdint.h>
   


### PR DESCRIPTION
The inclusion of `complex.h` inside `codec2_ofdm.h` was causing issues when building the new gnuradio-3.8.0.0 on OpenBSD 6.6 (see CMake snippet below). A cursory review of `codec2_ofdm.h` indicates that `complex.h` isn't actually needed. I haven't thoroughly tested this patch, but codec2 builds just fine, and it fixes the problem w/ gnuradio.

```
[ 29%] Building CXX object gr-vocoder/lib/CMakeFiles/gnuradio-vocoder.dir/freedv_api.cc.o
cd /home/int10h/src/gnuradio/build/gr-vocoder/lib && /usr/bin/c++  -DGR_CTRLPORT -DGR_MPLIB_MPIR -DGR_PERFORMANCE_COUNTERS -Dgnuradio_vocoder_EXPORTS -I/home/int10h/src/gnuradio/gr-vocoder/lib/../include -I/home/int10h/src/gnuradio/gnuradio-runtime/lib/../include -I/home/int10h/src/gnuradio/build/gnuradio-runtime/lib/../include -I/home/int10h/src/gnuradio/gnuradio-runtime/lib/pmt/../../include -I/home/int10h/src/gnuradio/build/volk/include -I/home/int10h/src/gnuradio/volk/include -isystem /usr/local/include -isystem /home/int10h/include -isystem /home/int10h/include/codec2  -O2 -march=ivybridge -fvisibility=hidden -Wsign-compare -Wall -Wno-uninitialized -DNDEBUG -fPIC   -std=c++11 -o CMakeFiles/gnuradio-vocoder.dir/freedv_api.cc.o -c /home/int10h/src/gnuradio/gr-vocoder/lib/freedv_api.cc
In file included from /home/int10h/src/gnuradio/gr-vocoder/lib/freedv_api.cc:27:
In file included from /home/int10h/src/gnuradio/gr-vocoder/lib/../include/gnuradio/vocoder/freedv_api.h:30:
In file included from /home/int10h/include/codec2/freedv_api.h:38:
In file included from /home/int10h/include/codec2/codec2_ofdm.h:33:
In file included from /usr/include/c++/v1/complex.h:29:
In file included from /usr/include/c++/v1/ccomplex:21:
In file included from /usr/include/c++/v1/complex:244:
/usr/include/c++/v1/type_traits:415:1: error: templates must have C++ linkage
template <class _T1, class _T2> struct _LIBCPP_TEMPLATE_VIS pair;
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/int10h/src/gnuradio/gr-vocoder/lib/../include/gnuradio/vocoder/freedv_api.h:28:1: note: extern "C" language linkage specification begins here
extern "C" {
^
```