### PR TITLE
Standardize Include files

### DIFF
--- a/src/codec2.h
+++ b/src/codec2.h
@@ -26,14 +26,14 @@
   along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef __cplusplus
-  extern "C" {
-#endif
-
 #ifndef __CODEC2__
 #define  __CODEC2__
 
 #include <codec2/version.h>
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
 
 #define CODEC2_MODE_3200 	0
 #define CODEC2_MODE_2400 	1
@@ -122,9 +122,9 @@ float *codec2_enable_user_ratek(struct CODEC2 *codec2_state, int *K);
 void codec2_700c_post_filter(struct CODEC2 *codec2_state, int en);
 void codec2_700c_eq(struct CODEC2 *codec2_state, int en);
       
-#endif
-
 #ifdef __cplusplus
 }
+#endif
+
 #endif
 

--- a/src/codec2_fdmdv.h
+++ b/src/codec2_fdmdv.h
@@ -38,6 +38,9 @@
 #ifndef __FDMDV__
 #define __FDMDV__
 
+#include "comp.h"
+#include "modem_stats.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -54,9 +57,6 @@ extern "C" {
 #else
 #define CODEC2_WIN32SUPPORT
 #endif
-
-#include "comp.h"
-#include "modem_stats.h"
 
 #define FDMDV_NC                      14  /* default number of data carriers                                */
 #define FDMDV_NC_MAX                  20  /* maximum number of data carriers                                */

--- a/src/fmfsk.h
+++ b/src/fmfsk.h
@@ -28,6 +28,7 @@
 
 #ifndef __C2FMFSK_H
 #define __C2FMFSK_H
+
 #include <stdint.h>
 #include "comp.h"
 #include "modem_stats.h"

--- a/src/freedv_api_internal.h
+++ b/src/freedv_api_internal.h
@@ -31,10 +31,6 @@
   along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef __cplusplus
-  extern "C" {
-#endif
-
 #ifndef __FREEDV_API_INTERNAL__
 #define __FREEDV_API_INTERNAL__
 
@@ -45,6 +41,10 @@
 #include "codec2_cohpsk.h"
 #ifdef __LPCNET__
 #include "lpcnet_freedv.h"
+#endif
+
+#ifdef __cplusplus
+  extern "C" {
 #endif
 
 // identifiers for no- Codec2 Speech codecs, make sure no overlpa with CODEC2_XXX modes
@@ -159,8 +159,9 @@ struct freedv {
     int n_protocol_bits;
 };
 
-#endif
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif
+

--- a/src/fsk.h
+++ b/src/fsk.h
@@ -28,6 +28,7 @@
 
 #ifndef __C2FSK_H
 #define __C2FSK_H
+
 #include <stdint.h>
 #include "comp.h"
 #include "kiss_fftr.h"

--- a/src/horus_api.h
+++ b/src/horus_api.h
@@ -26,15 +26,15 @@
   along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef __cplusplus
-  extern "C" {
-#endif
-
 #ifndef __HORUS_API__
+#define __HORUS_API__
 
 #include <stdint.h>
 #include "modem_stats.h"
-      
+
+#ifdef __cplusplus
+  extern "C" {
+#endif  
 #define HORUS_MODE_BINARY            0
 #define HORUS_MODE_RTTY              1
 
@@ -73,8 +73,9 @@ void          horus_set_total_payload_bits   (struct horus *hstates, int val);
 int           horus_get_max_demod_in         (struct horus *hstates);
 int           horus_get_max_ascii_out_len    (struct horus *hstates);
 
-#endif
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif
+

--- a/src/modem_probe.h
+++ b/src/modem_probe.h
@@ -27,6 +27,7 @@
 
 #ifndef __MODEMPROBE_H
 #define __MODEMPROBE_H
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <complex.h>

--- a/src/modem_stats.h
+++ b/src/modem_stats.h
@@ -25,15 +25,15 @@
   along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef __cplusplus
-  extern "C" {
-#endif
-
 #ifndef __MODEM_STATS__
 #define __MODEM_STATS__
 
 #include "comp.h"
 #include "kiss_fft.h"
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
 
 #define MODEM_STATS_NC_MAX      50
 #define MODEM_STATS_NR_MAX      8
@@ -81,8 +81,9 @@ void modem_stats_open(struct MODEM_STATS *f);
 void modem_stats_close(struct MODEM_STATS *f);
 void modem_stats_get_rx_spectrum(struct MODEM_STATS *f, float mag_spec_dB[], COMP rx_fdm[], int nin);
 
-#endif
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif
+

--- a/src/ofdm_internal.h
+++ b/src/ofdm_internal.h
@@ -28,18 +28,18 @@
 #ifndef OFDM_INTERNAL_H
 #define OFDM_INTERNAL_H
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <complex.h>
 #include <stdbool.h>
 #include <stdint.h>
 
 #include "codec2_ofdm.h"
 #include "filter.h"
-    
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #ifndef M_PI
 #define M_PI        3.14159265358979323846f
 #endif

--- a/src/tdma.h
+++ b/src/tdma.h
@@ -37,11 +37,10 @@
 #ifndef __CODEC_2_TDMA_H
 #define __CODEC_2_TDMA_H
 
-#include "fsk.h"
 #include <stdint.h>
 #include <stdbool.h>
 #include "comp_prim.h"
-
+#include "fsk.h"
 
 #define TDMA_FRAME_A 3   /* 4800T Frame */
 

--- a/stm32/inc/tm_stm32f4_gpio.h
+++ b/stm32/inc/tm_stm32f4_gpio.h
@@ -30,11 +30,6 @@
 #ifndef TM_GPIO_H
 #define TM_GPIO_H 150
 
-/* C++ detection */
-#ifdef __cplusplus
-extern "C" {
-#endif
-	
 /**
  * @addtogroup TM_STM32F4xx_Libraries
  * @{
@@ -93,6 +88,11 @@ extern "C" {
 #include "stm32f4xx.h"
 #include "stm32f4xx_gpio.h"
 #include "defines.h"
+
+/* C++ detection */
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @defgroup TM_GPIO_Macros

--- a/stm32/inc/tm_stm32f4_mco_output.h
+++ b/stm32/inc/tm_stm32f4_mco_output.h
@@ -30,11 +30,6 @@
 #ifndef TM_MCOOUTPUT_H
 #define TM_MCOOUTPUT_H 110
 
-/* C++ detection */
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * @addtogroup TM_STM32F4xx_Libraries
  * @{
@@ -85,12 +80,17 @@ extern "C" {
  - TM GPIO
 @endverbatim
  */
+
 #include "stm32f4xx.h"
 #include "stm32f4xx_rcc.h"
 #include "defines.h"
 #include "tm_stm32f4_gpio.h"
 
- 
+/* C++ detection */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @defgroup TM_MCO_Typedefs
  * @brief    Library Typedefs


### PR DESCRIPTION
Change include files to have the IFDEF wrapper first, then the include files, and then the C++ wrapper.

In order to standardize, and clean up some files that had it backwards.