### PR TITLE
QO-100 Sync 

### DIFF
--- a/octave/ofdm_ldpc_rx.m
+++ b/octave/ofdm_ldpc_rx.m
@@ -9,13 +9,21 @@ function time_to_sync = ofdm_ldpc_rx(filename, mode="700D", interleave_frames = 
   gp_interleaver;
   more off;
 
+  dpsk = 0;
+  if strcmp(mode,"700D-DPSK")
+    mode = "700D"; dpsk = 1;
+  end
+  if strcmp(mode,"2020-DPSK")
+    mode = "2020"; dpsk = 1;
+  end
+  
   % init modem
 
   [bps Rs Tcp Ns Nc] = ofdm_init_mode(mode);
   states = ofdm_init(bps, Rs, Tcp, Ns, Nc);
   ofdm_load_const;
   states.verbose = 1;
-  states.dpsk = 1;
+  states.dpsk = dpsk;
   %states.phase_est_bandwidth = "high";
   
   mod_order = 4; bps = 2; modulation = 'QPSK'; mapping = 'gray';

--- a/octave/ofdm_ldpc_rx.m
+++ b/octave/ofdm_ldpc_rx.m
@@ -15,6 +15,8 @@ function time_to_sync = ofdm_ldpc_rx(filename, mode="700D", interleave_frames = 
   states = ofdm_init(bps, Rs, Tcp, Ns, Nc);
   ofdm_load_const;
   states.verbose = 1;
+  states.dpsk = 1;
+  %states.phase_est_bandwidth = "high";
   
   mod_order = 4; bps = 2; modulation = 'QPSK'; mapping = 'gray';
   demod_type = 0; decoder_type = 0; max_iterations = 100;

--- a/octave/ofdm_lib.m
+++ b/octave/ofdm_lib.m
@@ -1008,7 +1008,7 @@ function states = sync_state_machine(states, rx_uw)
         states.sync_counter = 0;
       end
 
-      if states.sync_counter == 2
+      if states.sync_counter == 6
         next_state = "search";
         states.sync_state_interleaver = "search";
         states.phase_est_bandwidth = "high";

--- a/octave/ofdm_lib.m
+++ b/octave/ofdm_lib.m
@@ -300,7 +300,8 @@ function states = ofdm_init(bps, Rs, Tcp, Ns, Nc)
   states.foff_est_en = 1;
   states.phase_est_en = 1;
   states.phase_est_bandwidth = "high";
-
+  states.dpsk = 0;
+  
   states.foff_est_gain = 0.1;
   states.foff_est_hz = 0;
   states.sample_point = states.timing_est = 1;
@@ -672,7 +673,11 @@ function [rx_bits states aphase_est_pilot_log rx_np rx_amp] = ofdm_demod(states,
   for rr=1:Ns-1
     for c=2:Nc+1
       if phase_est_en
-        rx_corr = rx_sym(rr+2,c) * exp(-j*aphase_est_pilot(c));
+        if states.dpsk
+          rx_corr = rx_sym(rr+2,c) *  rx_sym(rr+1,c)';
+        else
+          rx_corr = rx_sym(rr+2,c) * exp(-j*aphase_est_pilot(c));
+        end
       else
         rx_corr = rx_sym(rr+2,c);
       end

--- a/octave/ofdm_lib.m
+++ b/octave/ofdm_lib.m
@@ -411,6 +411,9 @@ function tx = ofdm_txframe(states, tx_sym_lin)
     arowofsymbols = tx_sym_lin(s:s+Nc-1);
     s += Nc;
     aframe(r+1,2:Nc+1) = arowofsymbols;
+    if states.dpsk
+      aframe(r+1,2:Nc+1) = aframe(r+1,2:Nc+1) .* aframe(r,2:Nc+1);
+    end   
   end
   tx_sym = [tx_sym; aframe];
 
@@ -1005,7 +1008,7 @@ function states = sync_state_machine(states, rx_uw)
         states.sync_counter = 0;
       end
 
-      if states.sync_counter == 12
+      if states.sync_counter == 2
         next_state = "search";
         states.sync_state_interleaver = "search";
         states.phase_est_bandwidth = "high";

--- a/octave/ofdm_rx.m
+++ b/octave/ofdm_rx.m
@@ -9,6 +9,14 @@ function ofdm_rx(filename, mode="700D", error_pattern_filename)
   ofdm_lib;
   more off;
 
+  dpsk = 0;
+  if strcmp(mode,"700D-DPSK")
+    mode = "700D"; dpsk = 1;
+  end
+  if strcmp(mode,"2020-DPSK")
+    mode = "2020"; dpsk = 1;
+  end
+  
   % init modem
 
   [bps Rs Tcp Ns Nc] = ofdm_init_mode(mode);
@@ -16,7 +24,8 @@ function ofdm_rx(filename, mode="700D", error_pattern_filename)
   print_config(states);
   ofdm_load_const;
   states.verbose = 0;
-
+  states.dpsk=dpsk;
+  
   % load real samples from file
 
   Ascale = states.amp_scale/2; % as input is a real valued signal

--- a/octave/phase_noise.m
+++ b/octave/phase_noise.m
@@ -1,69 +1,72 @@
-% phase_nosie.m
+% phase_noise.m
 % David Nov 2019
-%
-% Close-in look at phase noise, feed in a off-air sample file of a sine wave
 
-% TODO
-%   [ ] estimate freq offset automatically
-%   [ ] labels on plots
-%   [ ] write float file we can use to run channel simulator
-%   [ ] can we estimate bandwith, or some other statistic?  Variance?
+% Close-in look at phase noise.  Feed in a off-air sample file of a
+% sine wave, extracts the phase noise countour and returns the Doppler
+% spreading function that can be used to model the channel in
+% simulations
 
-function phase_noise(file_name)
+function spread_FsHz = phase_noise(file_name)
   Fs = 8000;
   s = load_raw(file_name);
+  % skip past wave header
+  s = [zeros(256,1); s(256:end)];
   S = abs(fft(s(1:Fs).*hanning(Fs)));
   [mx mx_bin] = max(S);
-  ftone = mx_bin-1
+  ftone = mx_bin-1;
   
   figure(1); clf;
   plot(20*log10(S(1:Fs/2)))
   title('Input Spectrum');
   
-  % downshift to baseband and LPF
+  % downshift to baseband and LPF.  We just want the sinusoid with as little
+  % additive AWGN noise as possible
   sbb = s' .* exp(-j*(1:length(s))*2*pi*ftone/Fs);
-  sbb_lpf = filter(fir1(100,0.1),1,sbb);
+  [b a] = cheby1(4, 1, 20/Fs);
+  sbb_lpf = filter(b,a,sbb);
 
-  % estimate and remove fine freq offset
-  st = Fs; en = 4*Fs;
+  spread_fsHz = sbb_lpf;
+  
+  % estimate and remove fine freq offset, and HF phase noise
+  
+  st = Fs; en = 20*Fs;
   phase = unwrap(angle(sbb_lpf(st:en)));
   fine_freq = mean(phase(2:end) - phase(1:end-1));
   sbb_lpf_fine = sbb_lpf .* exp(-j*(1:length(sbb_lpf))*fine_freq);
+  phase = unwrap(angle(sbb_lpf_fine(st:en)));
+
+  printf("length: %3.2fs freq: %5.1f\n", length(s)/Fs, ftone+fine_freq*Fs/(2*pi));
 
   figure(2); clf;
-  subplot(211)
-  plot(real(sbb_lpf(st:en)));
-  title('real and imag')
-  subplot(212)
-  plot(imag(sbb_lpf_fine(st:en)));
-  
-  figure(3); clf;
-  plot(sbb_lpf_fine(st:en))
+  plot3((st:en)/Fs, real(sbb_lpf_fine(st:en)),imag(sbb_lpf_fine(st:en)))
   title('Polar phase trajectory');
 
-  figure(4); clf;
+  figure(3); clf;
   S2 = fftshift(fft(sbb_lpf_fine(Fs:Fs*11)));
-  middle = round(length(S2)/2)
-  [mx mx_bin] = max(abs(S2))
+  [mx mx_bin] = max(abs(S2));
   S2dB = 20*log10(abs(S2));
   mxdB = 10*ceil(max(S2dB)/10);
   x = -10:0.1:10;
   plot(x,S2dB(mx_bin-100:mx_bin+100));
   axis([-10 10 mxdB-40 mxdB])
-  title('Close in Phase Spectrum');
+  title('Close in Phase Noise Spectrum');
   xlabel('Freq (Hz)');
   grid;
   
   figure(5); clf;
-  plot(unwrap(angle(sbb_lpf_fine(st:en))))
+  t = (st:en)/Fs;
+  plot(t, phase,'b;phase;');
   title('Unwrapped Phase');
-  xlabel('Time (samples)')
+  xlabel('Time (sec)')
   ylabel('Phase (radians)')
   
   figure(6); clf;
-  rate_of_change_Hz = (phase(2:end) - phase(1:end-1))*Fs/(2*pi);
-  plot(medfilt1(rate_of_change_Hz,1000))
-  title('Instantaneous rate of change (Hz)');
-  xlabel('Time (samples)')
+  beta = 0.00001;
+  rate_of_change_Hz = filter(beta, [1 -(1-beta)],phase(2:end) - phase(1:end-1))*Fs/pi;
+  plot(t(2:end), rate_of_change_Hz)
+  title('Rate of change of phase (Hz)');
+  xlabel('Time (sec)')
   ylabel('Freq (Hz)')
+
+  spread_FsHz = sbb_lpf_fine/std(sbb_lpf_fine);
 end

--- a/octave/phase_noise.m
+++ b/octave/phase_noise.m
@@ -3,36 +3,67 @@
 %
 % Close-in look at phase noise, feed in a off-air sample file of a sine wave
 
+% TODO
+%   [ ] estimate freq offset automatically
+%   [ ] labels on plots
+%   [ ] write float file we can use to run channel simulator
+%   [ ] can we estimate bandwith, or some other statistic?  Variance?
+
 function phase_noise(file_name)
   Fs = 8000;
   s = load_raw(file_name);
   S = abs(fft(s(1:Fs).*hanning(Fs)));
   [mx mx_bin] = max(S);
-  ftone = mx_bin-3
+  ftone = mx_bin-1
+  
+  figure(1); clf;
+  plot(20*log10(S(1:Fs/2)))
+  title('Input Spectrum');
   
   % downshift to baseband and LPF
   sbb = s' .* exp(-j*(1:length(s))*2*pi*ftone/Fs);
   sbb_lpf = filter(fir1(100,0.1),1,sbb);
 
-  figure(1); clf;
-  plot(20*log10(S(1:Fs/2)))
+  % estimate and remove fine freq offset
+  st = Fs; en = 4*Fs;
+  phase = unwrap(angle(sbb_lpf(st:en)));
+  fine_freq = mean(phase(2:end) - phase(1:end-1));
+  sbb_lpf_fine = sbb_lpf .* exp(-j*(1:length(sbb_lpf))*fine_freq);
+
   figure(2); clf;
   subplot(211)
-  st = Fs; en = 4*Fs;
   plot(real(sbb_lpf(st:en)));
+  title('real and imag')
   subplot(212)
-  plot(imag(sbb_lpf(st:en)));
+  plot(imag(sbb_lpf_fine(st:en)));
+  
   figure(3); clf;
-  plot(sbb_lpf(st:en))
+  plot(sbb_lpf_fine(st:en))
+  title('Polar phase trajectory');
+
   figure(4); clf;
-  S2 = fftshift(fft(sbb_lpf(Fs:Fs*11)));
-  middle = length(S2)/2
+  S2 = fftshift(fft(sbb_lpf_fine(Fs:Fs*11)));
+  middle = round(length(S2)/2)
   [mx mx_bin] = max(abs(S2))
   S2dB = 20*log10(abs(S2));
   mxdB = 10*ceil(max(S2dB)/10);
   x = -10:0.1:10;
-  plot(x,S2dB(middle-100:middle+100));
+  plot(x,S2dB(mx_bin-100:mx_bin+100));
   axis([-10 10 mxdB-40 mxdB])
+  title('Close in Phase Spectrum');
+  xlabel('Freq (Hz)');
+  grid;
+  
   figure(5); clf;
-  plot(unwrap(angle(sbb_lpf(st:en))))
+  plot(unwrap(angle(sbb_lpf_fine(st:en))))
+  title('Unwrapped Phase');
+  xlabel('Time (samples)')
+  ylabel('Phase (radians)')
+  
+  figure(6); clf;
+  rate_of_change_Hz = (phase(2:end) - phase(1:end-1))*Fs/(2*pi);
+  plot(medfilt1(rate_of_change_Hz,1000))
+  title('Instantaneous rate of change (Hz)');
+  xlabel('Time (samples)')
+  ylabel('Freq (Hz)')
 end

--- a/octave/phase_noise.m
+++ b/octave/phase_noise.m
@@ -1,0 +1,38 @@
+% phase_nosie.m
+% David Nov 2019
+%
+% Close-in look at phase noise, feed in a off-air sample file of a sine wave
+
+function phase_noise(file_name)
+  Fs = 8000;
+  s = load_raw(file_name);
+  S = abs(fft(s(1:Fs).*hanning(Fs)));
+  [mx mx_bin] = max(S);
+  ftone = mx_bin-3
+  
+  % downshift to baseband and LPF
+  sbb = s' .* exp(-j*(1:length(s))*2*pi*ftone/Fs);
+  sbb_lpf = filter(fir1(100,0.1),1,sbb);
+
+  figure(1); clf;
+  plot(20*log10(S(1:Fs/2)))
+  figure(2); clf;
+  subplot(211)
+  st = Fs; en = 4*Fs;
+  plot(real(sbb_lpf(st:en)));
+  subplot(212)
+  plot(imag(sbb_lpf(st:en)));
+  figure(3); clf;
+  plot(sbb_lpf(st:en))
+  figure(4); clf;
+  S2 = fftshift(fft(sbb_lpf(Fs:Fs*11)));
+  middle = length(S2)/2
+  [mx mx_bin] = max(abs(S2))
+  S2dB = 20*log10(abs(S2));
+  mxdB = 10*ceil(max(S2dB)/10);
+  x = -10:0.1:10;
+  plot(x,S2dB(middle-100:middle+100));
+  axis([-10 10 mxdB-40 mxdB])
+  figure(5); clf;
+  plot(unwrap(angle(sbb_lpf(st:en))))
+end

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -1601,7 +1601,7 @@ void ofdm_sync_state_machine(struct OFDM *ofdm, uint8_t *rx_uw) {
                 ofdm->sync_counter = 0;
             }
 
-            if ((ofdm->sync_mode == autosync) && (ofdm->sync_counter > 6)) {
+            if ((ofdm->sync_mode == autosync) && (ofdm->sync_counter > 1)) {
                 /* run of consecutive bad frames ... drop sync */
 
                 next_state = search;

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -1601,7 +1601,7 @@ void ofdm_sync_state_machine(struct OFDM *ofdm, uint8_t *rx_uw) {
                 ofdm->sync_counter = 0;
             }
 
-            if ((ofdm->sync_mode == autosync) && (ofdm->sync_counter > 1)) {
+            if ((ofdm->sync_mode == autosync) && (ofdm->sync_counter > 6)) {
                 /* run of consecutive bad frames ... drop sync */
 
                 next_state = search;


### PR DESCRIPTION
Gerhard OE3GBB is still experiencing problems with 2020 sync over QO-100.  Some off-air samples files show (a) very slow to obtain sync (b) sometimes the freq offset appears wrong, (c) It loses sync after a few seconds.

1. Wrote ```octave/phase_noise.m``` to analyse some single sine wave off-air recordings Gerhard sent me.  

   This function also extracts and returns a Doppler spreading vector that can be used to simulate the QO-100 phase noise with the Octave OFDM modem simulations ```ofdm_tx/ofdm_rx```.  On the initial 30s tone sample it just had fairly slow variations in the phase that (at least with this sample) wasn't upsetting the demod.

   ![Screenshot from 2019-11-29 10-15-07](https://user-images.githubusercontent.com/45574645/69835390-2b0c3680-1291-11ea-82aa-3584e8012275.png)

1. Reduced the sync state machine run on time from 6 frames to 2, which allowed rapid resync.  Looking at the logs from:
   ```
   ./freedv_rx 2020 ~/Desktop/Gerhard/mode2020_sync_test3.wav /dev/null -vv --dpsk
   ```
   I could see a few frames of good decodes (LDPC parity check count = 108, 1 iteration of decoder), then burst of bad frames, and a re-sync with a freq offset 5 or 10Hz different.  This suggests a step change in the freq offset.

1. Running the Octave ```ofdm_rx``` simulation I could see the same thing, and generated this plot:, which clearly shows the step changes in frequency offset:
![Screenshot from 2019-11-29 07-24-17](https://user-images.githubusercontent.com/45574645/69835301-6eb27080-1290-11ea-927c-99a70bde8afd.png)

1. Unfortunately using the short sync run on time causes the ctest ```test_OFDM_modem_time_sync_700D``` to fail.  On low SNR HF channels the long run on helps give us time for the initial freq offset estimate to stabilise.  In this channel, the UW errors are initially high until the freq offset is tracked out after a few frames.  So reducing the sync run on counter threshold would cause premature loss of sync. 

1. One possibility is a user controllable sync run on time, we could make it shorter using a GUI option.  But that's a bit messy.  

1. This also raises the question of if we need DQPSK, perhaps the original problems on this channel were caused from step freq jumps too?  Using the Doppler spreading samples extracted from Gerhard's test tone, it appears DQPSK is helping:
   ```
   spread=phase_noise("~/Desktop/Gerhard/qo100_tone1.wav");
   ofdm_tx('test_2020.raw',"2020",20,10, spread)
   ofdm_rx('test_2020.raw',"2020")
   <snip>
   BER2.: 0.0930 Tbits: 42966 Terrs:  3996
   ofdm_tx('test_2020.raw',"2020-DPSK",20,10, spread)
   ofdm_rx('test_2020.raw',"2020-DPSK") 
   BER2.: 0.0057 Tbits: 42966 Terrs:   243
   ```

1. So - best to run this problem to ground - try to find the source of the mystery freq offset jumps, is it Gerhard's tx/rx or the satellite?

1. This is another reminder that in the next waveform we design we should use a higher pilot insertion rate to easily handle freq offsets of a few Hz using pilots alone.

1. Gerhard tracked the problem down to his hardware:

   >The problem was, that I was using a Bednar GPSDO for feeding the 25 MHz signal into the LNB. But the GPS-Signal is low because of a longer coax into the shack. So the GPSDO is sometimes looseing synchronisation to GPS and the PLL changed to TCXO and back. Bad error! 
 
   He is now reporting no problems with sync on QO-100 on both Linux and Windows builds on freedv-gui.  Acquisition range for him is +/- 50Hz.