### PR TITLE
Add CMake rule to ensure Codec2 is built with the correct OSX libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@
 # Please report questions, comments, problems, or patches to the freetel
 # mailing list: https://lists.sourceforge.net/lists/listinfo/freetel-codec2
 #
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
+
 project(codec2 C)
 
 cmake_minimum_required(VERSION 3.0)


### PR DESCRIPTION
Looks like the latest OSX SDK [adds a ____chkstk_darwin symbol reference libraries/executables built for 10.14 and later](https://github.com/Homebrew/homebrew-core/pull/46983#issuecomment-556906673). This results in crashes on older OSX releases when using a binary built on a newer version ([example](https://slexy.org/view/s21ec1R3gg)). 

Anyway, forcing CMAKE_OSX_DEPLOYMENT_TARGET like what's done on FreeDV resolves the issue.