### PR TITLE
ctest for c2enc/c2dec .c2 file mode & rm obsolete modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,4 +458,9 @@ endif()
              )
              set_tests_properties(test_FreeDV_700D_rx_memory_leak PROPERTIES PASS_REGULAR_EXPRESSION "ERROR SUMMARY: 0 errors")
 
+     add_test(NAME test_dot_c2_mode
+             COMMAND sh -c "$<TARGET_FILE:c2enc> 700C ~/codec2/raw/hts1a.raw hts1a.c2 && $<TARGET_FILE:c2dec> 1600 hts1a.c2 /dev/null"
+             )
+             set_tests_properties(test_dot_c2_mode PROPERTIES PASS_REGULAR_EXPRESSION "mode 8")
+
 endif(UNITTEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,7 +459,8 @@ endif()
              set_tests_properties(test_FreeDV_700D_rx_memory_leak PROPERTIES PASS_REGULAR_EXPRESSION "ERROR SUMMARY: 0 errors")
 
      add_test(NAME test_dot_c2_mode
-             COMMAND sh -c "$<TARGET_FILE:c2enc> 700C ~/codec2/raw/hts1a.raw hts1a.c2 && $<TARGET_FILE:c2dec> 1600 hts1a.c2 /dev/null"
+             COMMAND sh -c "./c2enc 700C ../../raw/hts1a.raw hts1a.c2 && ./c2dec 1600 hts1a.c2 /dev/null"
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src
              )
              set_tests_properties(test_dot_c2_mode PROPERTIES PASS_REGULAR_EXPRESSION "mode 8")
 

--- a/src/c2dec.c
+++ b/src/c2dec.c
@@ -141,10 +141,6 @@ int main(int argc, char *argv[])
         mode = CODEC2_MODE_1300;
         else if (strcmp(argv[1],"1200") == 0)
         mode = CODEC2_MODE_1200;
-        else if (strcmp(argv[1],"700") == 0)
-        mode = CODEC2_MODE_700;
-        else if (strcmp(argv[1],"700B") == 0)
-        mode = CODEC2_MODE_700B; 
         else if (strcmp(argv[1],"700C") == 0)
         mode = CODEC2_MODE_700C;
         else if (strcmp(argv[1],"450") == 0)
@@ -152,7 +148,7 @@ int main(int argc, char *argv[])
         else if (strcmp(argv[1],"450PWB") == 0)
         mode = CODEC2_MODE_450PWB;
         else {
-        fprintf(stderr, "Error in mode: %s.  Must be 3200, 2400, 1600, 1400, 1300, 1200, 700, 700B, 700C, 450, or 450PWB\n", argv[1]);
+        fprintf(stderr, "Error in mode: %s.  Must be 3200, 2400, 1600, 1400, 1300, 1200, 700C, 450, or 450PWB\n", argv[1]);
         exit(1);
         }
         bit_rate = atoi(argv[1]);

--- a/src/c2enc.c
+++ b/src/c2enc.c
@@ -51,9 +51,9 @@ int main(int argc, char *argv[])
     int            eq = 0;
     
     if (argc < 4) {
-	printf("usage: c2enc 3200|2400|1600|1400|1300|1200|700|700B|700C|450|450PWB InputRawspeechFile OutputBitFile [--natural] [--softdec] [--bitperchar] [--mlfeat] [--loadcb stageNum Filename] [--var] [--eq]\n");
-	printf("e.g    c2enc 1400 ../raw/hts1a.raw hts1a.c2\n");
-	printf("e.g    c2enc 1300 ../raw/hts1a.raw hts1a.c2 --natural\n");
+	printf("usage: c2enc 3200|2400|1600|1400|1300|1200|700C|450|450PWB InputRawspeechFile OutputBitFile [--natural] [--softdec] [--bitperchar] [--mlfeat] [--loadcb stageNum Filename] [--var] [--eq]\n");
+	printf("e.g. (headerless)    c2enc 1300 ../raw/hts1a.raw hts1a.bin\n");
+	printf("e.g. (with header to detect mode)   c2enc 1300 ../raw/hts1a.raw hts1a.c2\n");
 	exit(1);
     }
 
@@ -69,10 +69,6 @@ int main(int argc, char *argv[])
 	mode = CODEC2_MODE_1300;
     else if (strcmp(argv[1],"1200") == 0)
 	mode = CODEC2_MODE_1200;
-    else if (strcmp(argv[1],"700") == 0)
-	mode = CODEC2_MODE_700;
-    else if (strcmp(argv[1],"700B") == 0)
-	mode = CODEC2_MODE_700B;
     else if (strcmp(argv[1],"700C") == 0)
 	mode = CODEC2_MODE_700C;
     else if (strcmp(argv[1],"450") == 0)
@@ -80,7 +76,7 @@ int main(int argc, char *argv[])
     else if (strcmp(argv[1],"450PWB") == 0)
 	mode = CODEC2_MODE_450;
     else {
-	fprintf(stderr, "Error in mode: %s.  Must be 3200, 2400, 1600, 1400, 1300, 1200, 700, 700B, 700C, 450, 450PWB or WB\n", argv[1]);
+	fprintf(stderr, "Error in mode: %s.  Must be 3200, 2400, 1600, 1400, 1300, 1200, 700C, 450, 450PWB or WB\n", argv[1]);
 	exit(1);
     }
 

--- a/src/codec2.c
+++ b/src/codec2.c
@@ -75,10 +75,6 @@ void codec2_encode_1300(struct CODEC2 *c2, unsigned char * bits, short speech[])
 void codec2_decode_1300(struct CODEC2 *c2, short speech[], const unsigned char * bits, float ber_est);
 void codec2_encode_1200(struct CODEC2 *c2, unsigned char * bits, short speech[]);
 void codec2_decode_1200(struct CODEC2 *c2, short speech[], const unsigned char * bits);
-void codec2_encode_700(struct CODEC2 *c2, unsigned char * bits, short speech[]);
-void codec2_decode_700(struct CODEC2 *c2, short speech[], const unsigned char * bits);
-void codec2_encode_700b(struct CODEC2 *c2, unsigned char * bits, short speech[]);
-void codec2_decode_700b(struct CODEC2 *c2, short speech[], const unsigned char * bits);
 void codec2_encode_700c(struct CODEC2 *c2, unsigned char * bits, short speech[]);
 void codec2_decode_700c(struct CODEC2 *c2, short speech[], const unsigned char * bits);
 void codec2_encode_450(struct CODEC2 *c2, unsigned char * bits, short speech[]);
@@ -125,8 +121,6 @@ struct CODEC2 * codec2_create(int mode)
 		   || CODEC2_MODE_ACTIVE(CODEC2_MODE_1400, mode)
 		   || CODEC2_MODE_ACTIVE(CODEC2_MODE_1300, mode)
 		   || CODEC2_MODE_ACTIVE(CODEC2_MODE_1200, mode)
-		   || CODEC2_MODE_ACTIVE(CODEC2_MODE_700, mode)
-		   || CODEC2_MODE_ACTIVE(CODEC2_MODE_700B, mode)
 		   || CODEC2_MODE_ACTIVE(CODEC2_MODE_700C, mode)
 		   || CODEC2_MODE_ACTIVE(CODEC2_MODE_450, mode)
 		   || CODEC2_MODE_ACTIVE(CODEC2_MODE_450PWB, mode)
@@ -143,14 +137,14 @@ struct CODEC2 * codec2_create(int mode)
 
     /* store constants in a few places for convenience */
     
-    if( CODEC2_MODE_ACTIVE(CODEC2_MODE_450PWB, mode) == 0){
-		c2->c2const = c2const_create(8000, N_S);
-	}else{
-		c2->c2const = c2const_create(16000, N_S);
-	}
-	c2->Fs = c2->c2const.Fs;
-	int n_samp = c2->n_samp = c2->c2const.n_samp;
-	int m_pitch = c2->m_pitch = c2->c2const.m_pitch;
+    if (CODEC2_MODE_ACTIVE(CODEC2_MODE_450PWB, mode) == 0) {
+        c2->c2const = c2const_create(8000, N_S);
+    }else{
+        c2->c2const = c2const_create(16000, N_S);
+    }
+    c2->Fs = c2->c2const.Fs;
+    int n_samp = c2->n_samp = c2->c2const.n_samp;
+    int m_pitch = c2->m_pitch = c2->c2const.m_pitch;
 	
     c2->Pn = (float*)MALLOC(2*n_samp*sizeof(float));
     if (c2->Pn == NULL) {
@@ -206,11 +200,6 @@ struct CODEC2 * codec2_create(int mode)
 	return NULL;
     }
 
-    if ( CODEC2_MODE_ACTIVE(CODEC2_MODE_700B, mode))
-        c2->gray = 0;             // natural binary better for trellis decoding (hopefully added later)
-    else
-        c2->gray = 1;
-
     c2->lpc_pf = 1; c2->bass_boost = 1; c2->beta = LPCPF_BETA; c2->gamma = LPCPF_GAMMA;
 
     c2->xq_enc[0] = c2->xq_enc[1] = 0.0;
@@ -227,7 +216,8 @@ struct CODEC2 * codec2_create(int mode)
         c2->bpf_buf[i] = 0.0;
 
     c2->softdec = NULL;
-
+    c2->gray = 0;
+    
     /* newamp1 initialisation */
 
     if ( CODEC2_MODE_ACTIVE(CODEC2_MODE_700C, c2->mode)) {
@@ -316,18 +306,6 @@ struct CODEC2 * codec2_create(int mode)
 	c2->decode = codec2_decode_1200;
     }
 
-    if ( CODEC2_MODE_ACTIVE(CODEC2_MODE_700, c2->mode))
-    {
-	c2->encode = codec2_encode_700;
-	c2->decode = codec2_decode_700;
-    }
-
-    if ( CODEC2_MODE_ACTIVE(CODEC2_MODE_700B, c2->mode))
-    {
-	c2->encode = codec2_encode_700b;
-	c2->decode = codec2_decode_700b;
-    }
-
     if ( CODEC2_MODE_ACTIVE(CODEC2_MODE_700C, c2->mode))
     {
 	c2->encode = codec2_encode_700c;
@@ -411,10 +389,6 @@ int codec2_bits_per_frame(struct CODEC2 *c2) {
 	return 52;
     if  ( CODEC2_MODE_ACTIVE(CODEC2_MODE_1200, c2->mode))
 	return 48;
-    if  ( CODEC2_MODE_ACTIVE(CODEC2_MODE_700, c2->mode))
-	return 28;
-    if  ( CODEC2_MODE_ACTIVE(CODEC2_MODE_700B, c2->mode))
-	return 28;
     if  ( CODEC2_MODE_ACTIVE(CODEC2_MODE_700C, c2->mode))
 	return 28;
     if  ( CODEC2_MODE_ACTIVE(CODEC2_MODE_450, c2->mode))
@@ -448,10 +422,6 @@ int codec2_samples_per_frame(struct CODEC2 *c2) {
     if  ( CODEC2_MODE_ACTIVE(CODEC2_MODE_1300, c2->mode))
 	return 320;
     if  ( CODEC2_MODE_ACTIVE(CODEC2_MODE_1200, c2->mode))
-	return 320;
-    if  ( CODEC2_MODE_ACTIVE(CODEC2_MODE_700, c2->mode))
-	return 320;
-    if  ( CODEC2_MODE_ACTIVE(CODEC2_MODE_700B, c2->mode))
 	return 320;
     if  ( CODEC2_MODE_ACTIVE(CODEC2_MODE_700C, c2->mode))
 	return 320;
@@ -1526,415 +1496,6 @@ void codec2_decode_1200(struct CODEC2 *c2, short speech[], const unsigned char *
     c2->prev_model_dec = model[3];
     c2->prev_e_dec = e[3];
     for(i=0; i<LPC_ORD; i++)
-	c2->prev_lsps_dec[i] = lsps[3][i];
-}
-
-
-/*---------------------------------------------------------------------------*\
-
-  FUNCTION....: codec2_encode_700
-  AUTHOR......: David Rowe
-  DATE CREATED: April 2015
-
-  Encodes 320 speech samples (40ms of speech) into 28 bits.
-
-  The codec2 algorithm actually operates internally on 10ms (80
-  sample) frames, so we run the encoding algorithm four times:
-
-  frame 0: nothing
-  frame 1: nothing
-  frame 2: nothing
-  frame 3: voicing bit, scalar Wo and E, 17 bit LSP MEL scalar, 2 spare
-
-  The bit allocation is:
-
-    Parameter                      frames 1-3   frame 4   Total
-    -----------------------------------------------------------
-    Harmonic magnitudes (LSPs)          0         17        17
-    Energy                              0          3         3
-    log Wo                              0          5         5
-    Voicing                             0          1         1
-    spare                               0          2         2
-    TOTAL                               0         28        28
-
-\*---------------------------------------------------------------------------*/
-
-void codec2_encode_700(struct CODEC2 *c2, unsigned char * bits, short speech[])
-{
-    MODEL   model;
-    float   lsps[LPC_ORD_LOW];
-    float   mel[LPC_ORD_LOW];
-    float   ak[LPC_ORD_LOW+1];
-    float   e, f;
-    int     indexes[LPC_ORD_LOW];
-    int     Wo_index, e_index, i;
-    unsigned int nbit = 0;
-    float   bpf_out[4*c2->n_samp];
-    short   bpf_speech[4*c2->n_samp];
-    int     spare = 0;
-
-    assert(c2 != NULL);
-
-    memset(bits, '\0',  ((codec2_bits_per_frame(c2) + 7) / 8));
-
-    /* band pass filter */
-
-    for(i=0; i<BPF_N; i++)
-        c2->bpf_buf[i] = c2->bpf_buf[4*c2->n_samp+i];
-    for(i=0; i<4*c2->n_samp; i++)
-        c2->bpf_buf[BPF_N+i] = speech[i];
-    inverse_filter(&c2->bpf_buf[BPF_N], bpf, 4*c2->n_samp, bpf_out, BPF_N-1);
-    for(i=0; i<4*c2->n_samp; i++)
-        bpf_speech[i] = bpf_out[i];
-
-    /* frame 1 --------------------------------------------------------*/
-
-    analyse_one_frame(c2, &model, bpf_speech);
-
-    /* frame 2 --------------------------------------------------------*/
-
-    analyse_one_frame(c2, &model, &bpf_speech[c2->n_samp]);
-
-    /* frame 3 --------------------------------------------------------*/
-
-    analyse_one_frame(c2, &model, &bpf_speech[2*c2->n_samp]);
-
-    /* frame 4: - voicing, scalar Wo & E, scalar LSPs -----------------*/
-
-    analyse_one_frame(c2, &model, &bpf_speech[3*c2->n_samp]);
-    pack(bits, &nbit, model.voiced, 1);
-    Wo_index = encode_log_Wo(&c2->c2const, model.Wo, 5);
-    pack_natural_or_gray(bits, &nbit, Wo_index, 5, c2->gray);
-
-    e = speech_to_uq_lsps(lsps, ak, c2->Sn, c2->w, c2->m_pitch, LPC_ORD_LOW);
-    e_index = encode_energy(e, 3);
-    pack_natural_or_gray(bits, &nbit, e_index, 3, c2->gray);
-
-    for(i=0; i<LPC_ORD_LOW; i++) {
-        f = (4000.0/PI)*lsps[i];
-        mel[i] = floor(2595.0*log10(1.0 + f/700.0) + 0.5);
-    }
-    encode_mels_scalar(indexes, mel, LPC_ORD_LOW);
-
-    for(i=0; i<LPC_ORD_LOW; i++) {
-        pack_natural_or_gray(bits, &nbit, indexes[i], mel_bits(i), c2->gray);
-    }
-
-    pack_natural_or_gray(bits, &nbit, spare, 2, c2->gray);
-
-    assert(nbit == (unsigned)codec2_bits_per_frame(c2));
-}
-
-
-/*---------------------------------------------------------------------------*\
-
-  FUNCTION....: codec2_decode_700
-  AUTHOR......: David Rowe
-  DATE CREATED: April 2015
-
-  Decodes frames of 28 bits into 320 samples (40ms) of speech.
-
-\*---------------------------------------------------------------------------*/
-
-void codec2_decode_700(struct CODEC2 *c2, short speech[], const unsigned char * bits)
-{
-    MODEL   model[4];
-    int     indexes[LPC_ORD_LOW];
-    float   mel[LPC_ORD_LOW];
-    float   lsps[4][LPC_ORD_LOW];
-    int     Wo_index, e_index;
-    float   e[4];
-    float   snr, f_;
-    float   ak[4][LPC_ORD_LOW+1];
-    int     i,j;
-    unsigned int nbit = 0;
-    float   weight;
-    COMP    Aw[FFT_ENC];
-
-    assert(c2 != NULL);
-
-    /* only need to zero these out due to (unused) snr calculation */
-
-    for(i=0; i<4; i++)
-	for(j=1; j<=MAX_AMP; j++)
-	    model[i].A[j] = 0.0;
-
-    /* unpack bits from channel ------------------------------------*/
-
-    model[3].voiced = unpack(bits, &nbit, 1);
-    model[0].voiced = model[1].voiced = model[2].voiced = model[3].voiced;
-
-    Wo_index = unpack_natural_or_gray(bits, &nbit, 5, c2->gray);
-    model[3].Wo = decode_log_Wo(&c2->c2const, Wo_index, 5);
-    model[3].L  = PI/model[3].Wo;
-
-    e_index = unpack_natural_or_gray(bits, &nbit, 3, c2->gray);
-    e[3] = decode_energy(e_index, 3);
-
-    for(i=0; i<LPC_ORD_LOW; i++) {
-        indexes[i] = unpack_natural_or_gray(bits, &nbit, mel_bits(i), c2->gray);
-    }
-
-    decode_mels_scalar(mel, indexes, LPC_ORD_LOW);
-    for(i=0; i<LPC_ORD_LOW; i++) {
-        f_ = 700.0*( pow(10.0, (float)mel[i]/2595.0) - 1.0);
-        lsps[3][i] = f_*(PI/4000.0);
-        //printf("lsps[3][%d]  %f\n", i, lsps[3][i]);
-    }
-
-    check_lsp_order(&lsps[3][0], LPC_ORD_LOW);
-    bw_expand_lsps(&lsps[3][0], LPC_ORD_LOW, 50.0, 100.0);
-
-    #ifdef MASK_NOT_FOR_NOW
-    /* first pass at soft decn error masking, needs further work      */
-    /* If soft dec info available expand further for low power frames */
-
-    if (c2->softdec) {
-        float e = 0.0;
-        for(i=9; i<9+17; i++)
-            e += c2->softdec[i]*c2->softdec[i];
-        e /= 6.0;
-        //fprintf(stderr, "e: %f\n", e);
-        //if (e < 0.3)
-        //      bw_expand_lsps(&lsps[3][0], LPC_ORD_LOW, 150.0, 300.0);
-    }
-    #endif
-
-    /* interpolate ------------------------------------------------*/
-
-    /* LSPs, Wo, and energy are sampled every 40ms so we interpolate
-       the 3 frames in between, then recover spectral amplitudes */
-
-    for(i=0, weight=0.25; i<3; i++, weight += 0.25) {
-	interpolate_lsp_ver2(&lsps[i][0], c2->prev_lsps_dec, &lsps[3][0], weight, LPC_ORD_LOW);
-        interp_Wo2(&model[i], &c2->prev_model_dec, &model[3], weight, c2->c2const.Wo_min);
-        e[i] = interp_energy2(c2->prev_e_dec, e[3],weight);
-    }
-    for(i=0; i<4; i++) {
-	lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD_LOW);
-	aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD_LOW, &model[i], e[i], &snr, 0, 0,
-                  c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
-	apply_lpc_correction(&model[i]);
-	synthesise_one_frame(c2, &speech[c2->n_samp*i], &model[i], Aw, 1.0);
-    }
-
-    #ifdef DUMP
-    dump_lsp_(&lsps[3][0]);
-    dump_ak_(&ak[3][0], LPC_ORD_LOW);
-    dump_model(&model[3]);
-    if (c2->softdec)
-        dump_softdec(c2->softdec, nbit);
-    #endif
-
-    /* update memories for next frame ----------------------------*/
-
-    c2->prev_model_dec = model[3];
-    c2->prev_e_dec = e[3];
-    for(i=0; i<LPC_ORD_LOW; i++)
-	c2->prev_lsps_dec[i] = lsps[3][i];
-}
-
-
-/*---------------------------------------------------------------------------*\
-
-  FUNCTION....: codec2_encode_700b
-  AUTHOR......: David Rowe
-  DATE CREATED: August 2015
-
-  Version b of 700 bit/s codec.  After some experiments over the air I
-  wanted was unhappy with the rate 700 codec so spent a few weeks
-  trying to improve the speech quality. This version uses a wider BPF
-  and vector quantised mel-lsps.
-
-  Encodes 320 speech samples (40ms of speech) into 28 bits.
-
-  The codec2 algorithm actually operates internally on 10ms (80
-  sample) frames, so we run the encoding algorithm four times:
-
-  frame 0: nothing
-  frame 1: nothing
-  frame 2: nothing
-  frame 3: voicing bit, 5 bit scalar Wo and 3 bit E, 18 bit LSP MEL VQ,
-           1 spare
-
-  The bit allocation is:
-
-    Parameter                      frames 1-3   frame 4   Total
-    -----------------------------------------------------------
-    Harmonic magnitudes (LSPs)          0         18        18
-    Energy                              0          3         3
-    log Wo                              0          5         5
-    Voicing                             0          1         1
-    spare                               0          1         1
-    TOTAL                               0         28        28
-
-\*---------------------------------------------------------------------------*/
-
-void codec2_encode_700b(struct CODEC2 *c2, unsigned char * bits, short speech[])
-{
-    MODEL   model;
-    float   lsps[LPC_ORD_LOW];
-    float   mel[LPC_ORD_LOW];
-    float   mel_[LPC_ORD_LOW];
-    float   ak[LPC_ORD_LOW+1];
-    float   e, f;
-    int     indexes[3];
-    int     Wo_index, e_index, i;
-    unsigned int nbit = 0;
-    float   bpf_out[4*c2->n_samp];
-    short   bpf_speech[4*c2->n_samp];
-    int     spare = 0;
-
-    assert(c2 != NULL);
-
-    memset(bits, '\0',  ((codec2_bits_per_frame(c2) + 7) / 8));
-
-    /* band pass filter */
-
-    for(i=0; i<BPF_N; i++)
-        c2->bpf_buf[i] = c2->bpf_buf[4*c2->n_samp+i];
-    for(i=0; i<4*c2->n_samp; i++)
-        c2->bpf_buf[BPF_N+i] = speech[i];
-    inverse_filter(&c2->bpf_buf[BPF_N], bpfb, 4*c2->n_samp, bpf_out, BPF_N-1);
-    for(i=0; i<4*c2->n_samp; i++)
-        bpf_speech[i] = bpf_out[i];
-
-    /* frame 1 --------------------------------------------------------*/
-
-    analyse_one_frame(c2, &model, bpf_speech);
-
-    /* frame 2 --------------------------------------------------------*/
-
-    analyse_one_frame(c2, &model, &bpf_speech[c2->n_samp]);
-
-    /* frame 3 --------------------------------------------------------*/
-
-    analyse_one_frame(c2, &model, &bpf_speech[2*c2->n_samp]);
-
-    /* frame 4: - voicing, scalar Wo & E, VQ mel LSPs -----------------*/
-
-    analyse_one_frame(c2, &model, &bpf_speech[3*c2->n_samp]);
-    pack(bits, &nbit, model.voiced, 1);
-    Wo_index = encode_log_Wo(&c2->c2const, model.Wo, 5);
-    pack_natural_or_gray(bits, &nbit, Wo_index, 5, c2->gray);
-
-    e = speech_to_uq_lsps(lsps, ak, c2->Sn, c2->w, c2->m_pitch, LPC_ORD_LOW);
-    e_index = encode_energy(e, 3);
-    pack_natural_or_gray(bits, &nbit, e_index, 3, c2->gray);
-
-    for(i=0; i<LPC_ORD_LOW; i++) {
-        f = (4000.0/PI)*lsps[i];
-        mel[i] = floor(2595.0*log10(1.0 + f/700.0) + 0.5);
-    }
-    lspmelvq_mbest_encode(indexes, mel, mel_, LPC_ORD_LOW, 5);
-
-    for(i=0; i<3; i++) {
-        pack_natural_or_gray(bits, &nbit, indexes[i], lspmelvq_cb_bits(i), c2->gray);
-    }
-
-    pack_natural_or_gray(bits, &nbit, spare, 1, c2->gray);
-
-    assert(nbit == (unsigned)codec2_bits_per_frame(c2));
-}
-
-
-/*---------------------------------------------------------------------------*\
-
-  FUNCTION....: codec2_decode_700b
-  AUTHOR......: David Rowe
-  DATE CREATED: August 2015
-
-  Decodes frames of 28 bits into 320 samples (40ms) of speech.
-
-\*---------------------------------------------------------------------------*/
-
-void codec2_decode_700b(struct CODEC2 *c2, short speech[], const unsigned char * bits)
-{
-    MODEL   model[4];
-    int     indexes[3];
-    float   mel[LPC_ORD_LOW];
-    float   lsps[4][LPC_ORD_LOW];
-    int     Wo_index, e_index;
-    float   e[4];
-    float   snr, f_;
-    float   ak[4][LPC_ORD_LOW+1];
-    int     i,j;
-    unsigned int nbit = 0;
-    float   weight;
-    COMP    Aw[FFT_ENC];
-
-    assert(c2 != NULL);
-
-    /* only need to zero these out due to (unused) snr calculation */
-
-    for(i=0; i<4; i++)
-	for(j=1; j<=MAX_AMP; j++)
-	    model[i].A[j] = 0.0;
-
-    /* unpack bits from channel ------------------------------------*/
-
-    model[3].voiced = unpack(bits, &nbit, 1);
-    model[0].voiced = model[1].voiced = model[2].voiced = model[3].voiced;
-
-    Wo_index = unpack_natural_or_gray(bits, &nbit, 5, c2->gray);
-    model[3].Wo = decode_log_Wo(&c2->c2const, Wo_index, 5);
-    model[3].L  = PI/model[3].Wo;
-
-    e_index = unpack_natural_or_gray(bits, &nbit, 3, c2->gray);
-    e[3] = decode_energy(e_index, 3);
-
-    for(i=0; i<3; i++) {
-        indexes[i] = unpack_natural_or_gray(bits, &nbit, lspmelvq_cb_bits(i), c2->gray);
-    }
-
-    lspmelvq_decode(indexes, mel, LPC_ORD_LOW);
-
-    #define MEL_ROUND 10
-    for(i=1; i<LPC_ORD_LOW; i++) {
-        if (mel[i] <= mel[i-1]+MEL_ROUND) {
-            mel[i]+=MEL_ROUND/2;
-            mel[i-1]-=MEL_ROUND/2;
-            i = 1;
-        }
-    }
-
-    for(i=0; i<LPC_ORD_LOW; i++) {
-        f_ = 700.0*( pow(10.0, (float)mel[i]/2595.0) - 1.0);
-        lsps[3][i] = f_*(PI/4000.0);
-        //printf("lsps[3][%d]  %f\n", i, lsps[3][i]);
-    }
-
-    /* interpolate ------------------------------------------------*/
-
-    /* LSPs, Wo, and energy are sampled every 40ms so we interpolate
-       the 3 frames in between, then recover spectral amplitudes */
-
-    for(i=0, weight=0.25; i<3; i++, weight += 0.25) {
-	interpolate_lsp_ver2(&lsps[i][0], c2->prev_lsps_dec, &lsps[3][0], weight, LPC_ORD_LOW);
-        interp_Wo2(&model[i], &c2->prev_model_dec, &model[3], weight, c2->c2const.Wo_min);
-        e[i] = interp_energy2(c2->prev_e_dec, e[3],weight);
-    }
-    for(i=0; i<4; i++) {
-	lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD_LOW);
-	aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD_LOW, &model[i], e[i], &snr, 0, 0,
-                  c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
-	apply_lpc_correction(&model[i]);
-	synthesise_one_frame(c2, &speech[c2->n_samp*i], &model[i], Aw, 1.0);
-    }
-
-    #ifdef DUMP
-    dump_lsp_(&lsps[3][0]);
-    dump_ak_(&ak[3][0], LPC_ORD_LOW);
-    dump_model(&model[3]);
-    if (c2->softdec)
-        dump_softdec(c2->softdec, nbit);
-    #endif
-
-    /* update memories for next frame ----------------------------*/
-
-    c2->prev_model_dec = model[3];
-    c2->prev_e_dec = e[3];
-    for(i=0; i<LPC_ORD_LOW; i++)
 	c2->prev_lsps_dec[i] = lsps[3][i];
 }
 

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -42,8 +42,6 @@
 #endif
 
 #define FREEDV_MODE_1600        0
-#define FREEDV_MODE_700         1
-#define FREEDV_MODE_700B        2
 #define FREEDV_MODE_2400A       3
 #define FREEDV_MODE_2400B       4
 #define FREEDV_MODE_800XA       5

--- a/src/freedv_rx.c
+++ b/src/freedv_rx.c
@@ -105,7 +105,7 @@ int main(int argc, char *argv[]) {
         #ifdef __LPCNET__
         sprintf(f2020,"|2020");
         #endif     
-	printf("usage: %s 1600|700|700B|700C|700D|2400A|2400B|800XA%s InputModemSpeechFile OutputSpeechRawFile\n"
+	printf("usage: %s 1600|700C|700D|2400A|2400B|800XA%s InputModemSpeechFile OutputSpeechRawFile\n"
                " [--testframes] [--interleaver depth] [--codecrx] [-v] [--discard] [--usecomplex] [--dpsk]\n", argv[0],f2020);
 	printf("e.g    %s 1600 hts1a_fdmdv.raw hts1a_out.raw\n", argv[0]);
 	exit(1);
@@ -114,10 +114,6 @@ int main(int argc, char *argv[]) {
     mode = -1;
     if (!strcmp(argv[1],"1600"))
         mode = FREEDV_MODE_1600;
-    if (!strcmp(argv[1],"700"))
-        mode = FREEDV_MODE_700;
-    if (!strcmp(argv[1],"700B"))
-        mode = FREEDV_MODE_700B;
     if (!strcmp(argv[1],"700C"))
         mode = FREEDV_MODE_700C;
     if (!strcmp(argv[1],"700D"))
@@ -158,11 +154,7 @@ int main(int argc, char *argv[]) {
             if (strcmp(argv[i], "--codecrx") == 0) {
                 int c2_mode;
 
-                if (mode == FREEDV_MODE_700)  {
-		    c2_mode = CODEC2_MODE_700;
-		} else if ((mode == FREEDV_MODE_700B)|| (mode == FREEDV_MODE_800XA)) {
-                    c2_mode = CODEC2_MODE_700B;
-                } else if ((mode == FREEDV_MODE_700C)|| (mode == FREEDV_MODE_700D)) {
+                if ((mode == FREEDV_MODE_700C) || (mode == FREEDV_MODE_700D) || (mode == FREEDV_MODE_800XA)) {
                     c2_mode = CODEC2_MODE_700C;
                 } else {
                     c2_mode = CODEC2_MODE_1300;

--- a/src/freedv_tx.c
+++ b/src/freedv_tx.c
@@ -105,7 +105,7 @@ int main(int argc, char *argv[]) {
         #ifdef __LPCNET__
         sprintf(f2020,"|2020");
         #endif     
-        printf("usage: %s 1600|700|700B|700C|700D|2400A|2400B|800XA%s InputRawSpeechFile OutputModemRawFile\n"
+        printf("usage: %s 1600|700C|700D|2400A|2400B|800XA%s InputRawSpeechFile OutputModemRawFile\n"
                " [--testframes] [--interleave depth] [--codectx] [--datatx] [--clip 0|1] [--txbpf 0|1] [--extvco] [--dpsk]\n", argv[0], f2020);
         printf("e.g    %s 1600 hts1a.raw hts1a_fdmdv.raw\n", argv[0]);
         exit(1);
@@ -114,10 +114,6 @@ int main(int argc, char *argv[]) {
     mode = -1;
     if (!strcmp(argv[1],"1600"))
         mode = FREEDV_MODE_1600;
-    if (!strcmp(argv[1],"700"))
-        mode = FREEDV_MODE_700;
-    if (!strcmp(argv[1],"700B"))
-        mode = FREEDV_MODE_700B;
     if (!strcmp(argv[1],"700C"))
         mode = FREEDV_MODE_700C;
     if (!strcmp(argv[1],"700D"))
@@ -161,11 +157,7 @@ int main(int argc, char *argv[]) {
             if (strcmp(argv[i], "--codectx") == 0) {
                 int c2_mode;
                 
-                if (mode == FREEDV_MODE_700)  {
-                    c2_mode = CODEC2_MODE_700;
-                } else if ((mode == FREEDV_MODE_700B)|| (mode == FREEDV_MODE_800XA)) {
-                    c2_mode = CODEC2_MODE_700B;
-                } else if ((mode == FREEDV_MODE_700C)|| (mode == FREEDV_MODE_700D)) {
+                if ((mode == FREEDV_MODE_700C) || (mode == FREEDV_MODE_700D) || (mode == FREEDV_MODE_800XA)) {
                     c2_mode = CODEC2_MODE_700C;
                 } else {
                     c2_mode = CODEC2_MODE_1300;


### PR DESCRIPTION
1. Trap any repeat of the bug found in #88 with a ctest
1. Updated c2enc usage to make it clear how to use header (.c2) and headerless modes
1. Removed Codec 2 700 and 700B modes
1. Fixed an initialised variable bug affecting Codec 2/FreeDV 1600, memory leak ctest found it :-)
1. Removed obsolete FreeDV 700 and 700B modes