### PR TITLE
Fix reversion caused by change in graycode variable initialziation

### DIFF
--- a/src/codec2.c
+++ b/src/codec2.c
@@ -216,7 +216,7 @@ struct CODEC2 * codec2_create(int mode)
         c2->bpf_buf[i] = 0.0;
 
     c2->softdec = NULL;
-    c2->gray = 0;
+    c2->gray = 1;
     
     /* newamp1 initialisation */
 


### PR DESCRIPTION
While doing some work to rework the Flex Radio 6000 "Waveform" for FreeDV I encountered an issue where the audio was completely garbled.  After checking my code for the usual suspects, I started looking into the codec2 library itself.

After bisecting the code and testing, I found that a regression was introduced in c515387982bbe9f0ea9d6d0f50884716c0b1c6c4 that apparently causes the issue.  This change should fix the problem.  I have tested it in my code under 1600 and it looks good so far.  Have not checked other modes, but the change logically makes sense.