### PR TITLE
Use symmetrical hann in FSK

### DIFF
--- a/src/fsk.c
+++ b/src/fsk.c
@@ -95,18 +95,8 @@ static void fsk_generate_hann_table(struct FSK* fsk){
     int Ndft = fsk->Ndft;
     size_t i;
 
-    /* Set up complex oscilator to calculate hann function */
-    COMP dphi = comp_exp_j((2*M_PI)/((float)Ndft-1));
-    COMP rphi = {.5,0};
-    
-    rphi = cmult(cconj(dphi),rphi);
-    
     for(i=0; i<Ndft; i++){
-        rphi = cmult(dphi,rphi);
-        float hannc = .5-rphi.real;
-        //float hann = .5-(.5*cosf((2*M_PI*(float)(i))/((float)Ndft-1)));
-        
-        fsk->hann_table[i] = hannc;
+        fsk->hann_table[i] = 0.5 - 0.5 * cosf(2.0 * M_PI * (float)i / (float) (Ndft-1));
     }  
 }
 #endif
@@ -559,12 +549,6 @@ void fsk_demod_freq_est(struct FSK *fsk, COMP fsk_in[],float *freqs,int M){
     kiss_fft_cpx *fftout = (kiss_fft_cpx*)malloc(sizeof(kiss_fft_cpx)*Ndft);
     #endif
     
-    #ifndef USE_HANN_TABLE
-    COMP dphi = comp_exp_j((2*M_PI)/((float)Ndft-1));
-    COMP rphi = {.5,0};
-    rphi = cmult(cconj(dphi),rphi);
-    #endif
-    
     f_min  = (fsk->est_min*Ndft)/Fs;
     f_max  = (fsk->est_max*Ndft)/Fs;
     f_zero = (fsk->est_space*Ndft)/Fs;
@@ -588,9 +572,7 @@ void fsk_demod_freq_est(struct FSK *fsk, COMP fsk_in[],float *freqs,int M){
             #ifdef USE_HANN_TABLE
             hann = fsk->hann_table[i];
             #else
-            //hann = 1-cosf((2*M_PI*(float)(i))/((float)fft_samps-1));
-            rphi = cmult(dphi,rphi);
-            hann = .5-rphi.real;
+            hann = 0.5 - 0.5 * cosf(2.0 * M_PI * (float)i / (float) (fft_samps-1));
             #endif
             fftin[i].r = hann*fsk_in[i+Ndft*j].real;
             fftin[i].i = hann*fsk_in[i+Ndft*j].imag;


### PR DESCRIPTION
The current Hann table is not symmetric and goes negative in the last two indexes, and also goes over 1.0 in the center. The replacement formula was taken from elsewhere in the library and produces symmetrical values.