### PR TITLE
Remove tx filter deallocate from ofdm_destroy

### DIFF
--- a/src/codec2_ofdm.h
+++ b/src/codec2_ofdm.h
@@ -91,7 +91,7 @@ void ofdm_set_phase_est_enable(struct OFDM *, bool);
 void ofdm_set_phase_est_bandwidth_mode(struct OFDM *ofdm, int val);
 void ofdm_set_off_est_hz(struct OFDM *, float);
 void ofdm_set_sync(struct OFDM *, int);
-void ofdm_set_tx_bpf(struct OFDM *, bool);
+void ofdm_set_tx_bpf(bool);
 void ofdm_set_dpsk(struct OFDM *ofdm, bool val);
     
 void ofdm_print_info(struct OFDM *);

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -299,7 +299,7 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
 
 #ifndef __EMBEDDED__
         /* tx BPF off on embedded platforms, as it consumes significant CPU */
-        ofdm_set_tx_bpf(f->ofdm, 1);
+        ofdm_set_tx_bpf(1);
 #endif
 
     }
@@ -414,7 +414,7 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
 	}
         
         /* TODO: tx BPF off by default, as we need new filter coeffs for FreeDV 2020 waveform */
-        ofdm_set_tx_bpf(f->ofdm, 0);
+        ofdm_set_tx_bpf(0);
         
         codec2_mode = CODEC_MODE_LPCNET_1733; // not really codec 2 but got to call it something        
     }
@@ -2818,7 +2818,7 @@ void freedv_set_ext_vco                   (struct freedv *f, int val) {f->ext_vc
 
 void freedv_set_tx_bpf(struct freedv *f, int val) {
     if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)) {
-        ofdm_set_tx_bpf(f->ofdm, val);
+        ofdm_set_tx_bpf(val);
     }
 }
 

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -461,10 +461,6 @@ static void deallocate_tx_bpf(struct OFDM *ofdm) {
 void ofdm_destroy(struct OFDM *ofdm) {
     int i;
 
-    if (ofdm->ofdm_tx_bpf) {
-        deallocate_tx_bpf(ofdm);
-    }
-
     FREE(ofdm->pilot_samples);
     FREE(ofdm->rxbuf);
     FREE(ofdm->pilots);

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -90,6 +90,8 @@ static struct OFDM_CONFIG ofdm_config;
 
 
 static struct quisk_cfFilter *ofdm_tx_bpf;
+static bool ofdm_tx_bpf_en;
+
 static complex float *tx_uw_syms;
 static int *uw_ind;
 static int *uw_ind_sym;
@@ -435,9 +437,10 @@ struct OFDM *ofdm_create(const struct OFDM_CONFIG *config) {
     ofdm->timing_norm = (ofdm_m + ofdm_ncp) * acc;
     ofdm->clock_offset_counter = 0;
     ofdm->sig_var = ofdm->noise_var = 1.0f;
-    ofdm->tx_bpf_en = false;
     ofdm->dpsk = false;
-    
+
+    ofdm_tx_bpf_en = false;    
+
     return ofdm; /* Success */
 }
 
@@ -811,7 +814,7 @@ void ofdm_txframe(struct OFDM *ofdm, complex float *tx, complex float *tx_sym_li
 
     /* optional Tx Band Pass Filter */
 
-    if (ofdm->tx_bpf_en == true) {
+    if (ofdm_tx_bpf_en == true) {
         assert(ofdm_tx_bpf != NULL);
         complex float tx_filt[ofdm_samplesperframe];
 
@@ -880,12 +883,12 @@ void ofdm_set_tx_bpf(bool val) {
     if (val == true) {
     	 if (ofdm_tx_bpf == NULL)
              allocate_tx_bpf();
-    	ofdm->tx_bpf_en = true;
+    	ofdm_tx_bpf_en = true;
     }
     else {
     	if (ofdm_tx_bpf != NULL)
             deallocate_tx_bpf();
-    	ofdm->tx_bpf_en = false;
+    	ofdm_tx_bpf_en = false;
     }
 }
 
@@ -1898,7 +1901,7 @@ void ofdm_print_info(struct OFDM *ofdm) {
     fprintf(stderr, "ofdm->timing_en = %s\n", ofdm->timing_en ? "true" : "false");
     fprintf(stderr, "ofdm->foff_est_en = %s\n", ofdm->foff_est_en ? "true" : "false");
     fprintf(stderr, "ofdm->phase_est_en = %s\n", ofdm->phase_est_en ? "true" : "false");
-    fprintf(stderr, "ofdm->tx_bpf_en = %s\n", ofdm->tx_bpf_en ? "true" : "false");
+    fprintf(stderr, "ofdm_tx_bpf_en = %s\n", ofdm_tx_bpf_en ? "true" : "false");
     fprintf(stderr, "ofdm->dpsk = %s\n", ofdm->dpsk ? "true" : "false");
     fprintf(stderr, "ofdm->phase_est_bandwidth_mode = %s\n", phase_est_bandwidth_mode[ofdm->phase_est_bandwidth_mode]);
 }

--- a/src/ofdm_internal.h
+++ b/src/ofdm_internal.h
@@ -150,7 +150,6 @@ struct OFDM {
     bool timing_en;
     bool foff_est_en;
     bool phase_est_en;
-    bool tx_bpf_en;
     bool dpsk;
 };
 

--- a/src/ofdm_internal.h
+++ b/src/ofdm_internal.h
@@ -93,8 +93,6 @@ struct OFDM_CONFIG {
 
 struct OFDM {
     // Pointers
-
-    struct quisk_cfFilter *ofdm_tx_bpf;
     
     complex float *pilot_samples;
     complex float *rxbuf;

--- a/src/ofdm_mod.c
+++ b/src/ofdm_mod.c
@@ -339,7 +339,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (txbpf_en) {
-        ofdm_set_tx_bpf(ofdm, 1);
+        ofdm_set_tx_bpf(1);
     }
     if (dpsk) {
         ofdm_set_dpsk(ofdm, 1);


### PR DESCRIPTION
Fix for https://github.com/drowe67/codec2/issues/102, to support multiple parallel instances.