### PR TITLE
Update freedv_data_channel.c

### DIFF
--- a/src/freedv_data_channel.c
+++ b/src/freedv_data_channel.c
@@ -108,13 +108,9 @@ struct freedv_data_channel *freedv_data_channel_create(void)
 {
     struct freedv_data_channel *fdc;
   
-    fdc = malloc(sizeof(struct freedv_data_channel));
-    if (!fdc)
+    fdc = (struct freedv_data_channel *) calloc(1, sizeof(struct freedv_data_channel));
+    if (fdc == NULL)
         return NULL;
-
-    fdc->cb_rx = NULL;
-    fdc->cb_tx = NULL;
-    fdc->packet_tx_size = 0;
 
     freedv_data_set_header(fdc, fdc_header_bcast);
 


### PR DESCRIPTION
Previous version did not initialise packet_rx_cnt or packet_tx_cnt members of *fdc. This caused memory exception error in 800XA mode, as reported in https://github.com/drowe67/codec2/issues/105

Simple fix, proposed by @srsampson was to replace malloc() by calloc() and remove the then unnecessary initialisation of the other 3 members (packet_tx_size, cb_rx and cb_tx)