### PR TITLE
src/CMakeLists.txt: Remove horus_api.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -211,7 +211,6 @@ set(CODEC2_PUBLIC_HEADERS
     comp.h
     modem_stats.h
     freedv_api.h
-    horus_api.h
     ${CODEC2_VERSION_PATH}/version.h
 )
 


### PR DESCRIPTION
Fixes issue with cmake not finding the file during an install

https://github.com/m-ab-s/media-autobuild_suite/issues/1695