### PR TITLE
FSK modem support for TAP/TUN

### DIFF
--- a/octave/fsk_demod_file.m
+++ b/octave/fsk_demod_file.m
@@ -122,7 +122,6 @@ function fsk_demod_file(filename, format="s16", Fs=8000, Rs=50, M=2, P=8, max_se
     plot(f, RxdB);
     axis([-Fs/2 Fs/2 mx-80 mx])
     xlabel('Frequency (Hz)');
-    length(rx)
     if length(rx) > Fs
       figure(2); Ndft=2^ceil(log2(Fs/10)); specgram(rx,Ndft,Fs);
     end

--- a/octave/fsk_demod_file.m
+++ b/octave/fsk_demod_file.m
@@ -14,7 +14,7 @@
 
    Same thing but complex (single sided):
    
-   $ ./fsk_get_test_bits - 1000 | ./fsk_mod 2 8000 100 1000 1000 - - | ./cohpsk_ch - fsk.cs16 -100 --FS 8000 --complexout
+   $ ./fsk_get_test_bits - 1000 | ./fsk_mod 2 8000 100 1000 1000 - - | ./cohpsk_ch - fsk.cs16 -100 --Fs 8000 --complexout
    octave:2> fsk_demod_file("fsk.cs16",format="cs16",8000,100,2)
 #}
 
@@ -22,9 +22,8 @@ function fsk_demod_file(filename, format="s16", Fs=8000, Rs=50, M=2, max_secs=1E
   more off;
   fsk_lib;
   plot_en = 1;
-  
+
   states = fsk_init(Fs, Rs, M);
-  states.fest_min_spacing = 50000;
   
   if strcmp(format,"s16")
     read_complex = 0; sample_size = 'int16'; shift_fs_on_4=0;
@@ -37,7 +36,7 @@ function fsk_demod_file(filename, format="s16", Fs=8000, Rs=50, M=2, max_secs=1E
   end
 
   fin = fopen(filename,"rb");
-  if fin == -1 printf("Error opneing file: %s\n",filename); return; end
+  if fin == -1 printf("Error opening file: %s\n",filename); return; end
   
   nbit = states.nbit;
 
@@ -120,8 +119,8 @@ function fsk_demod_file(filename, format="s16", Fs=8000, Rs=50, M=2, max_secs=1E
     plot(f, RxdB);
     axis([-Fs/2 Fs/2 mx-80 mx])
     xlabel('Frequency (Hz)');
-
-    figure(2); specgram(rx,Fs);
+    length(rx)
+    figure(2); Ndft=2^ceil(log2(Fs/10)); specgram(rx,Ndft,Fs);
     figure(3); clf; plot(f_log,'+-'); axis([1 length(f_log) -Fs/2 Fs/2]); title('Tone Freq Estimates');    
     figure(4); clf; mesh(Sf_log(1:end,:)); title('Freq Est Sf over time');
     figure(5); clf; plot(f_int_resample_log','+'); title('Integrator outputs for each tone');

--- a/octave/fsk_lib.m
+++ b/octave/fsk_lib.m
@@ -190,7 +190,7 @@ function states = est_freq(states, sf, ntones)
   states.mask = mask;
   
   % drag mask over Sf, looking for peak in correlation
-  bmax = st; corr_max = 0;
+  b_max = st; corr_max = 0;
   Sf = states.Sf; corr_log = [];
   for b=st:en-length(mask)
     corr = mask * Sf(b:b+length(mask)-1);

--- a/src/cohpsk_ch.c
+++ b/src/cohpsk_ch.c
@@ -33,12 +33,12 @@
 #include <math.h>
 #include <errno.h>
 
+#include "codec2_fdmdv.h"
 #include "codec2_cohpsk.h"
 #include "comp_prim.h"
 #include "noise_samples.h"
 #include "ht_coeff.h"
 #include "ssbfilt_coeff.h"
-#include "codec2_fdmdv.h"
 
 #include "debug_alloc.h"
 
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
 	                          Channel
 	\*---------------------------------------------------------*/
 
-        fdmdv_freq_shift(ch_fdm, ch_in, foff_hz, &phase_ch, BUF_N);
+        fdmdv_freq_shift_coh(ch_fdm, ch_in, foff_hz, Fs, &phase_ch, BUF_N);
 
         /* optional HF fading -------------------------------------*/
 

--- a/src/fsk.h
+++ b/src/fsk.h
@@ -42,8 +42,10 @@
 #define FSK_SCALE 16383
 
 /* default internal parameters */
-#define FSK_DEFAULT_P 8
-#define FSK_DEFAULT_NSYM 50
+#define FSK_DEFAULT_P     8      /* Number of timing offsets we have to choose from, try to keep P >= 8 */
+#define FSK_DEFAULT_NSYM 50      /* how many symbols we average timing over, more gives a smoother estimate, 
+                                    but slower response */
+#define FSK_NONE         -1      /* unused parameter */
 
 struct FSK {
     /*  Static parameters set up by fsk_init */
@@ -57,7 +59,7 @@ struct FSK {
     int Nsym;               /* Number of symbols spat out in a processing frame */
     int Nbits;              /* Number of bits spat out in a processing frame */
     int f1_tx;              /* f1 for modulator */
-    int fs_tx;              /* Space between TX freqs for modulatosr */
+    int tone_spacing;       /* Space between TX freqs for modulator (and option mask freq estimator) */
     int mode;               /* 2FSK or 4FSK */
     float tc;               /* time constant for smoothing FFTs */
     int est_min;            /* Minimum frequency for freq. estimator */
@@ -95,24 +97,28 @@ struct FSK {
 };
 
 /*
- * Create an FSK config/state struct from a set of config parameters
+ * Create a FSK modem
  * 
  * int Fs - Sample frequency
  * int Rs - Symbol rate
- * int tx_f1 - '0' frequency
- * int tx_fs - frequency spacing
+ * int M  - 2 for 2FSK, 4 for 4FSK
+ * int f1_tx - first tone frequency
+ * int tone_spacing - frequency spacing (for modulator and optional "mask" freq estimator)
  */
-struct FSK * fsk_create(int Fs, int Rs, int M, int tx_f1, int tx_fs);
+struct FSK * fsk_create(int Fs, int Rs, int M, int f1_tx, int tone_spacing);
 
 /*
- * Create an FSK config/state struct from a set of config parameters
+ * Create a FSK modem - advanced version
  * 
  * int Fs - Sample frequency
  * int Rs - Symbol rate
- * int tx_f1 - '0' frequency
- * int tx_fs - frequency spacing
+ * int M  - 2 for 2FSK, 4 for 4FSK
+ * int P  - number of timing offsets to choose from (suggest >= 8)
+ * int Nsym  - windows size for timing estimator
+ * int f1_tx - first tone frequency
+ * int tone_spacing - frequency spacing (for modulator and optional "mask" freq estimator)
  */
-struct FSK * fsk_create_hbr(int Fs, int Rs, int M, int P, int Nsym, int tx_f1, int tx_fs);
+struct FSK * fsk_create_hbr(int Fs, int Rs, int M, int P, int Nsym, int f1_tx, int tone_spacing);
 
 /*
  * Set the minimum and maximum frequencies at which the freq. estimator can find tones

--- a/src/fsk_demod.c
+++ b/src/fsk_demod.c
@@ -75,7 +75,7 @@ int main(int argc,char *argv[]){
     int user_fsk_upper = 0;
     int nsym = FSK_DEFAULT_NSYM;
     int mask = 0;
-    int tx_tone_separation = 100;
+    int tone_separation = 100;
     
     int o = 0;
     int opt_idx = 0;
@@ -143,7 +143,7 @@ int main(int argc,char *argv[]){
             break;
         case 'm':
             mask = 1;
-            tx_tone_separation = atoi(optarg);
+            tone_separation = atoi(optarg);
             break;
         case 'h':
         case '?':
@@ -171,8 +171,9 @@ int main(int argc,char *argv[]){
         fprintf(stderr,"                    r, if provided, sets the number of modem frames between statistic printouts.\n");
         fprintf(stderr," -s --soft-dec      The output file will be in a soft-decision format, with one 32-bit float per bit.\n");
         fprintf(stderr,"                    If -s is not used, the output will be in a 1 byte-per-bit format.\n");
-        fprintf(stderr," -p P               The demod internals operate at a rate of Fs/P, default %d\n", FSK_DEFAULT_P);
-        fprintf(stderr,"                    P must be divisible by the symbol rate. Smaller P values will result in faster\n");
+        fprintf(stderr," -p P               Number of timing offsets we have to choose from, default %d.\n", FSK_DEFAULT_P);
+        fprintf(stderr,"                    Fs/Rs/P must be an integer.  Smaller values result in faster operation, but\n");
+        fprintf(stderr,"                    coarse sampling. Try to keep >= 8\n");
         fprintf(stderr,"                    processing but lower demodulation performance. Default %d\n", FSK_DEFAULT_P);
         fprintf(stderr," --fsk_lower freq   lower limit of freq estimator (default 0 for real input, -Fs/2  for complex input)\n");
         fprintf(stderr," --fsk_upper freq   upper limit of freq estimator (default Fs/2)\n");
@@ -205,8 +206,7 @@ int main(int argc,char *argv[]){
     }
 
     /* set up FSK */
-    #define UNUSED 1000
-    fsk = fsk_create_hbr(Fs,Rs,M,P,nsym,UNUSED,tx_tone_separation);
+    fsk = fsk_create_hbr(Fs,Rs,M,P,nsym,FSK_NONE,tone_separation);
 
     /* set freq estimator limits */
     if (!user_fsk_lower) {


### PR DESCRIPTION
# Introduction

Some exciting work going on with codec2 modems and VHF/UHF IP links:

1. Tomas's project: https://github.com/Tjoppen/codec2/tree/tms_tun uses a Pi and RTLSDR.
2. @JeroenVreeken  is also doing some fine work with his VHF packet protocol and a fork of freedv-gui https://github.com/JeroenVreeken/freedv-gui that supports a TAP device over COTs radios.

I'm using this PR to support them, and as a place for ongoing discussion.  I'd like to see a  "100 kbit/s IP link" for VHF/UHF using codec2 modems and  SDR. Moving Ham radio past the 1995-era "9600 data port" paradigm to real time IP.

# Plan

1. @Tjoppen I'm using this PR to mess with your modem samples.  First problem is I screwed up the documentation of the P parameter.  Have added more explanation in this PR.
2. Over The Bench (OTB) 100 kbit/s 2FSK test using Rpitx and RTL-SDR at UHF.