### PR TITLE
FreeDV API get hash function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,9 @@ if(UNITTEST)
     include(CTest)
     enable_testing()
 
+    add_test(NAME test_freedv_get_hash
+             COMMAND sh -c "${CMAKE_CURRENT_BINARY_DIR}/unittest/thash")
+
     add_test(NAME test_CML_ldpcut
              COMMAND sh -c "cd ${CMAKE_CURRENT_SOURCE_DIR}/octave; SHORT_VERSION_FOR_CTEST=1 octave --no-gui -qf ldpcut.m")
              set_tests_properties(test_CML_ldpcut PROPERTIES PASS_REGULAR_EXPRESSION "Nerr: 0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,29 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
+#
+# Find the git hash if this is a working copy.
+#
+if(EXISTS ${CMAKE_SOURCE_DIR}/.git)
+    find_package(Git QUIET)
+    if(Git_FOUND)
+        execute_process(
+            COMMAND "${GIT_EXECUTABLE}" describe --always HEAD
+            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+            RESULT_VARIABLE res
+            OUTPUT_VARIABLE FREEDV_HASH
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+        message(STATUS "freedv-gui current git hash: ${FREEDV_HASH}")
+        add_definitions(-DGIT_HASH="${FREEDV_HASH}")
+    else()
+        message(WARNING "Git not found. Can not determine current commit hash.")
+        add_definitions(-DGIT_HASH="Unknown")
+    endif()
+else()
+        add_definitions(-DGIT_HASH="None")
+endif()
+
 # Set default C flags.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-strict-overflow")
 

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -5,7 +5,11 @@
   DATE CREATED: August 2014
 
   Library of API functions that implement FreeDV "modes", useful for
-  embedding FreeDV in other programs.
+  embedding FreeDV in other programs.  Please see:
+
+  1. README_freedv.md
+  2. Notes function use in freedv_api.c
+  3. The sample freedv_tx.c and freedv_rx.c programs
 
 \*---------------------------------------------------------------------------*/
 
@@ -883,6 +887,21 @@ int freedv_rawdatarx(struct freedv *f, unsigned char *packed_payload_bits, short
 int freedv_get_version(void)
 {
     return VERSION;
+}
+
+/*---------------------------------------------------------------------------* \
+
+  FUNCTION....: freedv_get_hash
+  AUTHOR......: David Rowe
+  DATE CREATED: July 2020
+
+  Return the a string with the Git hash of the repo used to build this code.
+
+\*---------------------------------------------------------------------------*/
+
+void freedv_get_hash(char *git_hash)
+{
+    strcpy(git_hash, GIT_HASH);
 }
 
 /*---------------------------------------------------------------------------*\

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -899,9 +899,10 @@ int freedv_get_version(void)
 
 \*---------------------------------------------------------------------------*/
 
-void freedv_get_hash(char *git_hash, int max_len)
+static char git_hash[] = GIT_HASH;
+char *freedv_get_hash(void)
 {
-    strncpy(git_hash, GIT_HASH, max_len);
+    return git_hash;
 }
 
 /*---------------------------------------------------------------------------*\

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -899,9 +899,9 @@ int freedv_get_version(void)
 
 \*---------------------------------------------------------------------------*/
 
-void freedv_get_hash(char *git_hash)
+void freedv_get_hash(char *git_hash, int max_len)
 {
-    strcpy(git_hash, GIT_HASH);
+    strncpy(git_hash, GIT_HASH, max_len);
 }
 
 /*---------------------------------------------------------------------------*\

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -187,7 +187,7 @@ void freedv_set_eq                      (struct freedv *f, int val);
 struct MODEM_STATS;
 
 int freedv_get_version(void);
-void freedv_get_hash(char *git_hash, int max_len);
+char *freedv_get_hash(void);
 int freedv_get_mode                 (struct freedv *freedv);
 void freedv_get_modem_stats         (struct freedv *freedv, int *sync, float *snr_est);
 void freedv_get_modem_extended_stats(struct freedv *freedv, struct MODEM_STATS *stats);

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -187,7 +187,7 @@ void freedv_set_eq                      (struct freedv *f, int val);
 struct MODEM_STATS;
 
 int freedv_get_version(void);
-void freedv_get_hash(char *git_hash);
+void freedv_get_hash(char *git_hash, int max_len);
 int freedv_get_mode                 (struct freedv *freedv);
 void freedv_get_modem_stats         (struct freedv *freedv, int *sync, float *snr_est);
 void freedv_get_modem_extended_stats(struct freedv *freedv, struct MODEM_STATS *stats);

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -5,9 +5,11 @@
   DATE CREATED: August 2014
 
   Library of API functions that implement FreeDV "modes", useful for
-  embedding FreeDV in other programs.  Please see the documentation
-  for each function in freedv_api.c, and the sample freedv_tx.c and
-  freedv_rx.c programs.
+  embedding FreeDV in other programs.  Please see:
+
+  1. README_freedv.md
+  2. Notes function use in freedv_api.c
+  3. The sample freedv_tx.c and freedv_rx.c programs
 
 \*---------------------------------------------------------------------------*/
 
@@ -94,7 +96,7 @@
 // struct that hold state information for one freedv instance
 struct freedv;
 
-// Dummy structure for obsolete call
+// Dummy structure for (currently) deprecated call
 struct freedv_advanced {
     int interleave_frames;
 };
@@ -182,10 +184,10 @@ void freedv_set_eq                      (struct freedv *f, int val);
       
 // Get parameters -------------------------------------------------------------------------
 
-
 struct MODEM_STATS;
 
 int freedv_get_version(void);
+void freedv_get_hash(char *git_hash);
 int freedv_get_mode                 (struct freedv *freedv);
 void freedv_get_modem_stats         (struct freedv *freedv, int *sync, float *snr_est);
 void freedv_get_modem_extended_stats(struct freedv *freedv, struct MODEM_STATS *stats);

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -71,3 +71,6 @@ target_link_libraries(tfreedv_2400B_rawdata codec2)
 
 add_executable(tfsk_llr tfsk_llr.c)
 target_link_libraries(tfsk_llr codec2 m)
+
+add_executable(thash thash.c)
+target_link_libraries(thash codec2 m)

--- a/unittest/thash.c
+++ b/unittest/thash.c
@@ -11,12 +11,8 @@
 #include <stdio.h>
 #include "freedv_api.h"
 
-#define MAX_STR 16
-
 int main(void) { 
-    char hash[MAX_STR];
-    freedv_get_hash(hash, MAX_STR);
-    printf("%s\n", hash);
+    printf("%s\n", freedv_get_hash());
     return 0;
 }
 

--- a/unittest/thash.c
+++ b/unittest/thash.c
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------*\
+
+  FILE........: thash.c
+  AUTHOR......: David Rowe
+  DATE CREATED: July 2020
+
+  Simple test program for freeDV API get hash function
+
+\*---------------------------------------------------------------------------*/
+
+#include <stdio.h>
+#include "freedv_api.h"
+
+#define MAX_STR 16
+
+int main(void) { 
+    char hash[MAX_STR];
+    freedv_get_hash(hash, MAX_STR);
+    printf("%s\n", hash);
+    return 0;
+}
+
+


### PR DESCRIPTION
Use case is making sure freedv-gui is fining the right version of codec2 and LPCNet, e.g. after re-install with multiple shared libraries/DLLs on a system.