### PR TITLE
Make native build compatible with cmake within cmake build

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,31 +200,32 @@ On Ubuntu 17 and above:
  ```
 
 
-## Including codec2 in an Android project
+## Including Codec 2 in an Android project
 
 In an Android Studio 'NDK' project (a project that uses 'native' code)
-codec2 can be added to the project in the following way.
+Codec 2 can be added to the project in the following way.
 
-1. Add the codec2 source tree to you app (e.g. in app/src/main/codec2)
-   (e.g. as a git sub-module)
+1. Add the Codec 2 source tree to your app (e.g. in app/src/main/codec2)
+   (e.g. as a git sub-module).
 
-1. Add codec2 to the CMakeList.txt (app/src/main/cpp/CMakeLists.txt)
+1. Add Codec 2 to the CMakeList.txt (app/src/main/cpp/CMakeLists.txt):
 
- ```
-# Sets lib_src_DIR to the path of the target CMake project.
-set( codec2_src_DIR ../codec2/ )
-# Sets lib_build_DIR to the path of the desired output directory.
-set( codec2_build_DIR ../codec2/ )
-file(MAKE_DIRECTORY ${codec2_build_DIR})
+    ```
+    # Sets lib_src_DIR to the path of the target CMake project.
+    set( codec2_src_DIR ../codec2/ )
+    # Sets lib_build_DIR to the path of the desired output directory.
+    set( codec2_build_DIR ../codec2/ )
+    file(MAKE_DIRECTORY ${codec2_build_DIR})
 
-add_subdirectory( ${codec2_src_DIR} ${codec2_build_DIR} )
+    add_subdirectory( ${codec2_src_DIR} ${codec2_build_DIR} )
 
-include_directories(
-        ${codec2_src_DIR}/src
-        ${CMAKE_CURRENT_BINARY_DIR}/../codec2
-)
- ```
-1. Add 'codec2' to the target_link_libraries in the same file
+    include_directories(
+	    ${codec2_src_DIR}/src
+	    ${CMAKE_CURRENT_BINARY_DIR}/../codec2
+    )
+    ```
+     
+1. Add Codec 2 to the target_link_libraries in the same file.
 
 
 

--- a/README.md
+++ b/README.md
@@ -199,3 +199,32 @@ On Ubuntu 17 and above:
  wait for it to build.
  ```
 
+
+## Including codec2 in an Android project
+
+In an Android Studio 'NDK' project (a project that uses 'native' code)
+codec2 can be added to the project in the following way.
+
+1. Add the codec2 source tree to you app (e.g. in app/src/main/codec2)
+   (e.g. as a git sub-module)
+
+1. Add codec2 to the CMakeList.txt (app/src/main/cpp/CMakeLists.txt)
+
+ ```
+# Sets lib_src_DIR to the path of the target CMake project.
+set( codec2_src_DIR ../codec2/ )
+# Sets lib_build_DIR to the path of the desired output directory.
+set( codec2_build_DIR ../codec2/ )
+file(MAKE_DIRECTORY ${codec2_build_DIR})
+
+add_subdirectory( ${codec2_src_DIR} ${codec2_build_DIR} )
+
+include_directories(
+        ${codec2_src_DIR}/src
+        ${CMAKE_CURRENT_BINARY_DIR}/../codec2
+)
+ ```
+1. Add 'codec2' to the target_link_libraries in the same file
+
+
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,16 +63,20 @@ set(CODEBOOKSNEWAMP2_ENERGY
 
 # when crosscompiling we need a native executable
 if(CMAKE_CROSSCOMPILING)
+    set(CMAKE_DISABLE_SOURCE_CHANGES OFF)
     include(ExternalProject)
     ExternalProject_Add(codec2_native
-       SOURCE_DIR ${CMAKE_SOURCE_DIR}
-       BUILD_COMMAND $(MAKE) generate_codebook
-       INSTALL_COMMAND ${CMAKE_COMMAND} -E copy src/generate_codebook ${CMAKE_CURRENT_BINARY_DIR}
+       SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..
+       BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/codec2_native
+       BUILD_COMMAND ${CMAKE_COMMAND} --build . --target generate_codebook
+       INSTALL_COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/codec2_native/src/generate_codebook ${CMAKE_CURRENT_BINARY_DIR}
+       BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/generate_codebook
     )
     add_executable(generate_codebook IMPORTED)
     set_target_properties(generate_codebook PROPERTIES
         IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/generate_codebook)
     add_dependencies(generate_codebook codec2_native)
+    set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 else(CMAKE_CROSSCOMPILING)
 # Build code generator binaries. These do not get installed.
     # generate_codebook


### PR DESCRIPTION
Some small changes to the native build for cross compiling.
With these changes it is possible to build codec2 as a native lib(s) in android studio and integrate it into android apps.
Unfortunatly the slightly 'special' generate_codebook native build needs a bit of help to get it to work.
- Use 'current' instead of top level dir as this might not be codec2 in case of a nested build.
- Use the cmake prefered tool instead of make (android studio uses ninja)
- Choose our own build dir (android studios choice is wildly different from regular linux build and might break to install/copy action)
- Specify generate_codebook as a build byproduct as ninja does not understand build time generated dependencies as well as make
