### PR TITLE
Support for data demos

### DIFF
--- a/src/freedv_700.c
+++ b/src/freedv_700.c
@@ -520,7 +520,7 @@ int freedv_comp_short_rx_ofdm(struct freedv *f, void *demod_in_8kHz, int demod_i
     ofdm_sync_state_machine(ofdm, rx_uw);
 
     if ((f->verbose && (ofdm->last_sync_state == search)) || (f->verbose == 2)) {
-        fprintf(stderr, "%3d nin: %4d st: %-6s euw: %2d %1d mf: %2d f: %5.1f pbw: %d snr: %4.1f eraw: %3d ecdd: %3d iter: %3d "
+        fprintf(stderr, "%3d nin: %4d st: %-6s euw: %2d %2d mf: %2d f: %5.1f pbw: %d snr: %4.1f eraw: %3d ecdd: %3d iter: %3d "
                 "pcc: %3d rxst: %s\n",
                 f->frames++, ofdm->nin,
                 ofdm_statemode[ofdm->last_sync_state],

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -1248,7 +1248,7 @@ void freedv_set_carrier_ampl(struct freedv *f, int c, float ampl) {
 void freedv_set_sync(struct freedv *freedv, int sync_cmd) {
     assert (freedv != NULL);
 
-    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, freedv->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700E, freedv->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2020, freedv->mode)) {
+    if (freedv->ofdm != NULL) {
         ofdm_set_sync(freedv->ofdm, sync_cmd);
     }
 }

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -64,7 +64,7 @@
 // peak (complex) sample value from Tx modulator
 #define FREEDV_PEAK             16384
 
-// Return code flags for freedv_*rx* functions
+// Return code flags for freedv_get_rx_status() function
 #define FREEDV_RX_TRIAL_SYNC       0x1       // demodulator has trial sync
 #define FREEDV_RX_SYNC             0x2       // demodulator has sync
 #define FREEDV_RX_BITS             0x4       // data bits have been returned

--- a/src/freedv_data_raw_rx.c
+++ b/src/freedv_data_raw_rx.c
@@ -47,12 +47,14 @@ int main(int argc, char *argv[]) {
     int                        mode;
     int                        verbose = 0, use_testframes = 0;
     int                        mask = 0;
+    int                        resetsync = 0;
 
     if (argc < 3) {
     helpmsg:
       	fprintf(stderr, "usage: %s [options] FSK_LDPC|DATAC1|DATAC2|DATAC3 InputModemSpeechFile BinaryDataFile\n"
-               "  -v or --vv      verbose options\n"
-               "  --testframes    count raw and coded errors in testframes sent by tx\n"
+               "  -v or --vv              verbose options\n"
+               "  --testframes            count raw and coded errors in testframes sent by tx\n"
+               "  --resetsync  Nframes    reset sync after Nframes received\n"
                "\n"
                "For FSK_LDPC only:\n\n"
                "  -m      2|4     number of FSK tones\n"
@@ -73,6 +75,7 @@ int main(int argc, char *argv[]) {
             {"Rs",         required_argument,  0, 'r'},
             {"vv",         no_argument,        0, 'x'},
             {"mask",       required_argument,  0, 'k'},
+            {"resetsync",  required_argument,  0, 's'},
             {0, 0, 0, 0}
         };
 
@@ -91,6 +94,9 @@ int main(int argc, char *argv[]) {
             break;
         case 'r':
             adv.Rs = atoi(optarg);
+            break;
+        case 's':
+            resetsync = atoi(optarg);
             break;
         case 't':
             use_testframes = 1;
@@ -178,6 +184,8 @@ int main(int argc, char *argv[]) {
             fwrite(bytes_out, sizeof(uint8_t), nbytes-2, fout);
             nbytes_out += nbytes-2;
             nframes_out++;
+            if (resetsync && (nframes_out >= resetsync))
+                freedv_set_sync(freedv, FREEDV_SYNC_UNSYNC);
         }
 
         if (verbose == 3) {


### PR DESCRIPTION
Support for @DJ2LS  TNC work https://github.com/DJ2LS/FreeDV-Socket-TNC/tree/dev/test

## Fixed freedv_set_sync() for data modes

The data mode state machine doesn't have any logic to lose sync once a burst ends, as this is problematic for HF channels where frames may be lost due to fades.  Instead it relies on knowledge from higher layers about when the burst of frames from the Tx ends.  For example both the Tx and Rx may know that a fixed number of frames will be sent, or that the frames must arrive in a certain time window.

Here is a demo of freedv_data_raw_rx resetting sync after `resetsync` frames have been received.  Three bursts of 3 frames are sent by the Tx.  The Rx resets the state machine after it receives 3 frames, so it is ready to sync up on the next burst.

```
~/codec2/build_linux/src/freedv_data_raw_tx DATAC3 /dev/zero - --testframes 3 --bursts 3 | ~/codec2/build_linux/src/freedv_data_raw_rx DATAC3 - /dev/null --resetsync 3 -vv | hexdump
<snip>
modem bufs processed: 171  output bytes: 270 output_frames: 9
``` 

This method will fail when a frame is lost.  A real world TNC could use a timer:
1. Start Rx running.  Modem is waiting for burst of frames to start.
1. Start a timer with a period equivalent to the taken to receive N frames.
1. When N frames arrive, or timer fires, reset modem state machine.  Modem is now ready for a new burst of frames.