### PR TITLE
Remove shell prompts from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,75 +16,75 @@ Also included:
 
 1. Install packages (Debian/Ubuntu):
    ```
-   $ sudo apt install git build-essential cmake
+   sudo apt install git build-essential cmake
    ```
    Fedora/RH distros:
    ```
-   $ sudo dnf groupinstall "Development Tools" "C Development Tools and Libraries"
-   $ sudo dnf install cmake
+   sudo dnf groupinstall "Development Tools" "C Development Tools and Libraries"
+   sudo dnf install cmake
    ```
    
 1. Build Codec 2:
    ```
-   $ git clone git@github.com:drowe67/codec2.git
-   $ cd codec2
-   $ mkdir build_linux
-   $ cd build_linux
-   $ cmake ..
-   $ make
+   git clone git@github.com:drowe67/codec2.git
+   cd codec2
+   mkdir build_linux
+   cd build_linux
+   cmake ..
+   make
    ```
 
 1. Listen to Codec 2 (run from ```codec2/build_linux```):
    ```
-   $ ./src/c2demo ../raw/hts1a.raw hts1a_c2.raw
-   $ aplay -f S16_LE ../raw/hts1a.raw
-   $ aplay -f S16_LE hts1a_c2.raw
+   ./src/c2demo ../raw/hts1a.raw hts1a_c2.raw
+   aplay -f S16_LE ../raw/hts1a.raw
+   aplay -f S16_LE hts1a_c2.raw
    ```
 1. Compress, decompress and then play a file using Codec 2 at 2400 bit/s:
    ```
-   $ ./src/c2enc 2400 ../raw/hts1a.raw hts1a_c2.bit
-   $ ./src/c2dec 2400 hts1a_c2.bit hts1a_c2_2400.raw 
+   ./src/c2enc 2400 ../raw/hts1a.raw hts1a_c2.bit
+   ./src/c2dec 2400 hts1a_c2.bit hts1a_c2_2400.raw 
    ```
    which can be played with:
    ```
-   $ aplay -f S16_LE hts1a_c2_2400.raw
+   aplay -f S16_LE hts1a_c2_2400.raw
    ```
    Or using Codec 2 using 700C (700 bits/s):
    ```
-   $ ./src/c2enc 700C ../raw/hts1a.raw hts1a_c2.bit
-   $ ./src/c2dec 700C hts1a_c2.bit hts1a_c2_700.raw
-   $ aplay -f S16_LE hts1a_c2_700.raw
+   ./src/c2enc 700C ../raw/hts1a.raw hts1a_c2.bit
+   ./src/c2dec 700C hts1a_c2.bit hts1a_c2_700.raw
+   aplay -f S16_LE hts1a_c2_700.raw
    ```
 1. If you prefer a one-liner without saving to files:
    ```
-   $ ./src/c2enc 1300 ../raw/hts1a.raw - | ./src/c2dec 1300 - - | aplay -f S16_LE
+   ./src/c2enc 1300 ../raw/hts1a.raw - | ./src/c2dec 1300 - - | aplay -f S16_LE
    ```
    
 ## FreeDV 2020 support (building with LPCNet)
 
 1. Build codec2 initially without LPCNet
    ```
-   $ cd ~
-   $ git clone https://github.com/drowe67/codec2.git
-   $ cd codec2 && mkdir build_linux && cd build_linux
-   $ cmake ../
-   $ make
+   cd ~
+   git clone https://github.com/drowe67/codec2.git
+   cd codec2 && mkdir build_linux && cd build_linux
+   cmake ../
+   make
    ```
 
 1. Build LPCNet:
    ```
-   $ cd ~
-   $ git clone https://github.com/drowe67/LPCNet
-   $ cd LPCNet && mkdir build_linux && cd build_linux
-   $ cmake -DCODEC2_BUILD_DIR=~/codec2/build_linux ../ 
-   $ make
+   cd ~
+   git clone https://github.com/drowe67/LPCNet
+   cd LPCNet && mkdir build_linux && cd build_linux
+   cmake -DCODEC2_BUILD_DIR=~/codec2/build_linux ../ 
+   make
    ```
 
 1. (Re)build Codec 2 with LPCNet support:
    ```
-   $ cd ~/codec2/build_linux && rm -Rf *
-   $ cmake -DLPCNET_BUILD_DIR=~/LPCNet/build_linux ..
-   $ make
+   cd ~/codec2/build_linux && rm -Rf *
+   cmake -DLPCNET_BUILD_DIR=~/LPCNet/build_linux ..
+   make
    ```
 
 ## Programs
@@ -113,37 +113,37 @@ CTest is used as a test framework, with support from [GNU Octave](https://www.gn
 
 1. Install GNU Octave and libraries on Ubuntu with:
    ```
-   $ sudo apt install octave octave-common octave-signal liboctave-dev gnuplot python3-numpy sox valgrind
+   sudo apt install octave octave-common octave-signal liboctave-dev gnuplot python3-numpy sox valgrind
    ```
 1. Install CML library with instructions at the top of [```octave/ldpc.m```](octave/ldpc.m)
 
 1. To build and run the tests:
    ```
-   $ cd ~/codec2
-   $ rm -Rf build_linux && mkdir build_linux
-   $ cd build_linux
-   $ cmake -DCMAKE_BUILD_TYPE=Debug ..
-   $ make all test
+   cd ~/codec2
+   rm -Rf build_linux && mkdir build_linux
+   cd build_linux
+   cmake -DCMAKE_BUILD_TYPE=Debug ..
+   make all test
    ```
 
 1. To just run tests without rebuilding:
    ```
-   $ ctest
+   ctest
    ```
 
 1. To get a verbose run (e.g. for test debugging):
    ```
-   $ ctest -V
+   ctest -V
    ```
 
 1. To just run a single test:
    ```
-   $ ctest -R test_OFDM_modem_octave_port
+   ctest -R test_OFDM_modem_octave_port
    ```
 
 1. To list the available tests:
    ```
-   $ ctest -N
+   ctest -N
    ```
 
 ## Directories
@@ -163,30 +163,30 @@ wav         - speech files in wave file format
 
 1. To compile with debug symbols for using gdb:
    ```
-   $ cd ~/codec2
-   $ rm -Rf build_linux && mkdir build_linux
-   $ cd build_linux
-   $ CFLAGS=-g cmake ..
-   $ make
+   cd ~/codec2
+   rm -Rf build_linux && mkdir build_linux
+   cd build_linux
+   CFLAGS=-g cmake ..
+   make
    ```
 
 1. For dump file support (dump data from c2sim for input to Octave development scripts):
    ```
-   $ cd ~/codec2
-   $ rm -Rf build_linux && mkdir build_linux
-   $ cd build_linux
-   $ CFLAGS=-DDUMP cmake ..
-   $ make
+   cd ~/codec2
+   rm -Rf build_linux && mkdir build_linux
+   cd build_linux
+   CFLAGS=-DDUMP cmake ..
+   make
    ```
 
 ## Building for Windows on a Linux machine
 
 On Ubuntu 17 and above:
    ```
-   $ sudo apt-get install mingw-w64
-   $ mkdir build_windows && cd build_windows
-   $ cmake .. -DCMAKE_TOOLCHAIN_FILE=/home/david/freedv-dev/cmake/Toolchain-Ubuntu-mingw32.cmake -DUNITTEST=FALSE -DGENERATE_CODEBOOK=/home/david/codec2/build_linux/src/generate_codebook 
-   $ make
+   sudo apt-get install mingw-w64
+   mkdir build_windows && cd build_windows
+   cmake .. -DCMAKE_TOOLCHAIN_FILE=/home/david/freedv-dev/cmake/Toolchain-Ubuntu-mingw32.cmake -DUNITTEST=FALSE -DGENERATE_CODEBOOK=/home/david/codec2/build_linux/src/generate_codebook 
+   make
    ```
    
 ## Building for Windows on a Windows machine


### PR DESCRIPTION
Not having them makes copying-and-pasting to the shell a lot easier.