### PR TITLE
cmake: add libraries needed by freedv-gui

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -222,6 +222,9 @@ set(CODEC2_PUBLIC_HEADERS
     modem_stats.h
     freedv_api.h
     ${CODEC2_VERSION_PATH}/version.h
+    kiss_fft.h
+    varicode.h
+    comp_prim.h
 )
 
 #


### PR DESCRIPTION
This is essentially an issue that should be discussed.
I updated codec2/freedv-gui macports packages to the latest commit and to build freedv-gui I need the following library on /opt/local/include (they are requested by `modem_stats.h` and `.h` in freedv-gui). This patch accomplishes this request but, for example,kiss_fft is an external project and it should not be copied.
What do you think?