### PR TITLE
Resolve compiler errors on macOS Big Sur (11.0).

### DIFF
--- a/src/fmfsk_demod.c
+++ b/src/fmfsk_demod.c
@@ -28,6 +28,7 @@
 */
 
 #include <stdio.h>
+#include <string.h>
 #include "fmfsk.h"
 #include "modem_stats.h"
 #define MODEMPROBE_ENABLE

--- a/src/fmfsk_mod.c
+++ b/src/fmfsk_mod.c
@@ -29,6 +29,7 @@
 */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "fmfsk.h"
 #include "codec2_fdmdv.h"

--- a/unittest/tqam16.c
+++ b/unittest/tqam16.c
@@ -9,6 +9,7 @@
 \*---------------------------------------------------------------------------*/
 
 #include <stdio.h>
+#include <string.h>
 #include "ofdm_internal.h"
 
 int main(void) {


### PR DESCRIPTION
Resolves issue #165 by adding missing header files to several files in the tree that fail to compile. 