### PR TITLE
Use different SNR value to determine whether to open squelch.

### DIFF
--- a/src/fdmdv.c
+++ b/src/fdmdv.c
@@ -677,8 +677,8 @@ void generate_pilot_lut(COMP pilot_lut[], COMP *pilot_freq)
 	if (f >= 4)
 	    memcpy(&pilot_lut[M_FAC*(f-4)], pilot, M_FAC*sizeof(COMP));
     }
-   
-    // create complex conjugate since we need this and only this later on 
+
+    // create complex conjugate since we need this and only this later on
     for (f=0;f<4*M_FAC;f++)
     {
         pilot_lut[f] = cconj(pilot_lut[f]);
@@ -841,8 +841,8 @@ float rx_est_freq_offset(struct FDMDV *f, COMP rx_fdm[], int nin, int do_fft)
 	f->pilot_baseband2[j] = cmult(rx_fdm[i], prev_pilot[i]);
     }
 #else
-    // TODO: Maybe a handwritten mult taking advantage of rx_fdm[0] being 
-    // used twice would be faster but this is for sure faster than 
+    // TODO: Maybe a handwritten mult taking advantage of rx_fdm[0] being
+    // used twice would be faster but this is for sure faster than
     // the implementation above in any case.
     arm_cmplx_mult_cmplx_f32(&rx_fdm[0].real,&pilot[0].real,&f->pilot_baseband1[NPILOTBASEBAND-nin].real,nin);
     arm_cmplx_mult_cmplx_f32(&rx_fdm[0].real,&prev_pilot[0].real,&f->pilot_baseband2[NPILOTBASEBAND-nin].real,nin);
@@ -1157,13 +1157,13 @@ void down_convert_and_rx_filter(COMP rx_filt[NC+1][P+1], int Nc, COMP rx_fdm[],
         entire rx_fdm_mem array.  To downconvert these we need the LO
         phase referenced to the start of the rx_fdm_mem array.
 
-      
+
         <--------------- Nrx_filt_mem ------->
         nin
         |--------------------------|---------|
         1                          |
         phase_rx(c)
-     
+
         This means winding phase(c) back from this point
         to ensure phase continuity.
 
@@ -1257,7 +1257,7 @@ float rx_est_timing(COMP rx_symbols[],
     adjust = P - nin*P/m;
 
     /* update buffer of NT rate P filtered symbols */
- 
+
     for(c=0; c<Nc+1; c++)
 	for(i=0,j=P-adjust; i<(NT-1)*P+adjust; i++,j++)
 	    rx_filter_mem_timing[c][i] = rx_filter_mem_timing[c][j];
@@ -1318,7 +1318,7 @@ float rx_est_timing(COMP rx_symbols[],
 
     /* This value will be +/- half a symbol so will wrap around at +/-
        M/2 or +/- 80 samples with M=160 */
-    
+
     return norm_rx_timing*m;
 }
 
@@ -1635,7 +1635,7 @@ void fdmdv_demod(struct FDMDV *fdmdv, int rx_bits[],
     PROFILE_SAMPLE(demod_start);
     foff_coarse = rx_est_freq_offset(fdmdv, rx_fdm_bb, *nin, !fdmdv->sync);
     PROFILE_SAMPLE_AND_LOG(fdmdv_freq_shift_start, demod_start, "    rx_est_freq_offset");
-    
+
     if (fdmdv->sync == 0)
 	fdmdv->foff = foff_coarse;
     fdmdv_freq_shift(rx_fdm_fcorr, rx_fdm_bb, -fdmdv->foff, &fdmdv->foff_phase_rect, *nin);
@@ -1956,6 +1956,9 @@ void fdmdv_simulate_channel(float *sig_pwr_av, COMP samples[], int nin, float ta
     float sig_pwr, target_snr_linear, noise_pwr, noise_pwr_1Hz, noise_pwr_4000Hz, noise_gain;
     int   i;
 
+    /* prevent NAN when we divide by nin below */
+    if (nin == 0) return;
+
     /* estimate signal power */
 
     sig_pwr = 0.0;
@@ -1982,6 +1985,6 @@ void fdmdv_simulate_channel(float *sig_pwr_av, COMP samples[], int nin, float ta
     }
     /*
     fprintf(stderr, "sig_pwr: %f f->sig_pwr_av: %e target_snr_linear: %f noise_pwr_4000Hz: %e noise_gain: %e\n",
-            sig_pwr, f->sig_pwr_av, target_snr_linear, noise_pwr_4000Hz, noise_gain);
+            sig_pwr, *sig_pwr_av, target_snr_linear, noise_pwr_4000Hz, noise_gain);
     */
 }

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -855,7 +855,7 @@ int freedv_bits_to_speech(struct freedv *f, short speech_out[], short demod_in[]
            }
            else {
                /* sync is solid - decode even through fades as there is still some speech info there */
-               if (f->stats.snr_est > f->snr_squelch_thresh)
+               if (f->snr_est > f->snr_squelch_thresh)
                    decode_speech = 1;
            }
        }

--- a/src/freedv_fsk.c
+++ b/src/freedv_fsk.c
@@ -581,6 +581,7 @@ int freedv_comprx_fsk(struct freedv *f, COMP demod_in[]) {
             demod_in_float[i] = demod_in[i].real;
         }
         fmfsk_demod(f->fmfsk,(uint8_t*)f->tx_bits,demod_in_float);
+        f->snr_est = f->fmfsk->snr_mean;
         f->nin = fmfsk_nin(f->fmfsk);
     }
 


### PR DESCRIPTION
@drowe67, this resolves drowe67/freedv-gui#81, where squelch must be set below 0dB for FreeDV to emit any audio for 800XA at all (regardless of the actual SNR).