### PR TITLE
Better handling of all zero OFDM Input

### DIFF
--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -130,8 +130,8 @@ complex float qpsk_mod(int *bits) {
 void qpsk_demod(complex float symbol, int *bits) {
     complex float rotate = symbol * cmplx(ROT45);
 
-    bits[0] = crealf(rotate) < 0.0f;
-    bits[1] = cimagf(rotate) < 0.0f;
+    bits[0] = crealf(rotate) <= 0.0f;
+    bits[1] = cimagf(rotate) <= 0.0f;
 }
 
 complex float qam16_mod(int *bits) {


### PR DESCRIPTION
@tmiw [discovered](https://github.com/drowe67/freedv-gui/pull/111#issuecomment-810909652) that 700D/E would not fall out of sync when the modem signal ended and was followed by all zero samples.  I think this is because the unique word (UW) is all 0 bits, and 0+0j QPSK symbol is demodulated to `00` - matching the UW.

This PR changes the QPSK symbol mapping to address that.  A better solution (in hindsight) would be a UW that isn't all zeros.

@srsampson you might be interested in this one!