### PR TITLE
Single carrier PSK modem

### DIFF
--- a/octave/ofdm_lib.m
+++ b/octave/ofdm_lib.m
@@ -367,7 +367,10 @@ function config = ofdm_init_mode(mode="700D")
     config.state_machine = "data"; 
     config.amp_scale = 300E3; config.clip_gain1 = 2.2; config.clip_gain2 = 0.8;
   elseif strcmp(mode,"1")
-    Ns=5; config.Np=10; Tcp=0; Tframe = 0.1; Ts = Tframe/Ns; Nc = 1;
+    Ns=5; config.Np=10; Tcp=0; Ts=0.010; Nc = 1;
+    config.state_machine = "data"; config.data_mode = "streaming";
+    config.edge_pilots = 0;    
+    config.Ntxtbits = 0; config.Nuwbits = 10; config.bad_uw_errors = 3;
   else
     % try to parse mode string for user defined mode
     vec = sscanf(mode, "Ts=%f Nc=%d Ncp=%f");
@@ -395,7 +398,10 @@ function print_config(states)
     for r=1:Ns
       for c=cr
         if r == 1
-          sym="P";
+          sym=" ";
+          if states.edge_pilots || (c>1 && c <=(Nc+1))
+             sym="P";
+          end
         elseif c>1 && c <=(Nc+1)
           sym=".";
           if (u <= Nuwsyms) && (s == uw_ind_sym(u)) sym="U"; u++; end


### PR DESCRIPTION
@srsampson I recall you were interested in single carrier modems (QO-100 is a good use case, or UHF).  Turns out the recent data work to the OFDM modem includes the features we need to make single carrier operation work.  Only it's not really OFDM any more as there's no other carriers to be orthogonal too!

Uncoded, burst mode Octave demo:
```
ofdm_tx("test_single.raw","1",1,100,"awgn","bursts",3)
ofdm_rx("test_single.raw","1","packetsperburst",1)
<snip>
BER..: 0.0000 Tbits:   240 Terrs:     0
Packets:   3 Npre: 3 Npost: 0 SNR3k: 16.18
```

I'm working on another project atm, but if you want to push this fwd I'm happy to assist.  Or we can leave it for later :slightly_smiling_face: Obvious addition would be a raised cosine (root Nyquist) filter.  We have them already on some other modems (FDMDV cohpsk).  I just took a guess at the waveform design (it's a low symbol rate), feel free to mess around with it.

![Screenshot from 2021-04-30 09-39-22](https://user-images.githubusercontent.com/45574645/116633190-06415480-a998-11eb-8220-77a819d93165.png)
![Screenshot from 2021-04-30 09-39-27](https://user-images.githubusercontent.com/45574645/116633176-fcb7ec80-a997-11eb-960d-465f89473f15.png)
