### PR TITLE
stop overwriting FFT states when sampling modem_stats with OFDM modes

### DIFF
--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -1404,7 +1404,7 @@ void freedv_get_modem_extended_stats(struct freedv *f, struct MODEM_STATS *stats
     if (is_ofdm_mode(f)) {
         // OFDM modem stats updated when demod runs, so copy last update
         // We need to avoid over writing the FFT states which are updated by a different function
-        // TODO we need a better ddesign here: Issue #182
+        // TODO we need a better design here: Issue #182
         size_t ncopy = (void*)stats->rx_eye - (void*)stats;
         memcpy(stats, &f->stats, ncopy);
     }

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -1402,8 +1402,11 @@ void freedv_get_modem_extended_stats(struct freedv *f, struct MODEM_STATS *stats
     }
 
     if (is_ofdm_mode(f)) {
-        // OFDM modem stats updated when demod runs, just copy last update
-        memcpy(stats, &f->stats, sizeof(struct MODEM_STATS));
+        // OFDM modem stats updated when demod runs, so copy last update
+        // We need to avoid over writing the FFT states which are updated by a different function
+        // TODO we need a better ddesign here: Issue #182
+        size_t ncopy = (void*)stats->rx_eye - (void*)stats;
+        memcpy(stats, &f->stats, ncopy);
     }
 }
 


### PR DESCRIPTION
@tmiw Can you please try this with freedv-gui and see if it resolves the segfault issue with 84e43e2 ?  It works OK for me.

This is a short term fix, I have documented the related design issue in https://github.com/drowe67/codec2/issues/182 so it can be fixed properly at some stage.