### PR TITLE
SNR nans from ofdm

### DIFF
--- a/src/cohpsk_ch.c
+++ b/src/cohpsk_ch.c
@@ -220,7 +220,7 @@ int main(int argc, char *argv[])
         //fprintf(stderr, "hf_gain: %f\n", hf_gain);
     }
 
-    assert(2*HT_N == sizeof(ht_coeff)/sizeof(float));
+    assert(HT_N == sizeof(ht_coeff)/sizeof(COMP));
     for(i=0; i<HT_N; i++) {
         htbuf[i] = 0.0;
     }

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -133,8 +133,7 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
          FDV_MODE_ACTIVE( FREEDV_MODE_FSK_LDPC, mode) ||
          FDV_MODE_ACTIVE( FREEDV_MODE_DATAC0, mode)   ||
          FDV_MODE_ACTIVE( FREEDV_MODE_DATAC1, mode)   ||
-         FDV_MODE_ACTIVE( FREEDV_MODE_DATAC3, mode))
-         == false) return NULL;
+         FDV_MODE_ACTIVE( FREEDV_MODE_DATAC3, mode)) == false) return NULL;
 
     /* set everything to zero just in case */
     f = (struct freedv*)CALLOC(1, sizeof(struct freedv));

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -799,7 +799,7 @@ int freedv_comprx(struct freedv *f, short speech_out[], COMP demod_in[]) {
 
 int freedv_shortrx(struct freedv *f, short speech_out[], short demod_in[], float gain) {
     assert(f != NULL);
-    int rx_status;
+    int rx_status = 0;
     f->nin_prev = f->nin;
 
     // At this stage short interface only supported for 700D, to help

--- a/src/ldpc_dec.c
+++ b/src/ldpc_dec.c
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
     Tbits = Terrs = Tbits_raw = Terrs_raw = Tpackets = Tpacketerrs = 0;
     
     FILE *fin, *fout;
-    int   sdinput, nread, offset;
+    int   sdinput, nread, offset=0;
 
     /* File I/O mode ------------------------------------------------*/
 

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -1792,15 +1792,15 @@ float ofdm_esno_est_calc(complex float *rx_sym, int nsym) {
         noise_var = sig_var;
     noise_var *= 2.0f;
     
-    float EsNodB = 10.0*log10((1E-12+sig_var)/(1E-12+noise_var));
+    float EsNodB = 10.0f * log10f((1E-12f + sig_var) / (1E-12f + noise_var));
     assert(isnan(EsNodB) == 0);
     return EsNodB;
 }
 
 
 float ofdm_snr_from_esno(struct OFDM *ofdm, float EsNodB) {
-    float cyclic_power = 10.0*log10((float)(ofdm->ncp+ofdm->m)/ofdm->m);
-    return EsNodB + 10.0*log10((float)(ofdm->nc*ofdm->rs)/3000.0) + cyclic_power;
+    float cyclic_power = 10.0f * log10f((float)(ofdm->ncp + ofdm->m) / ofdm->m);
+    return EsNodB + 10.0f * log10f((float)(ofdm->nc * ofdm->rs) / 3000.0f) + cyclic_power;
 }
 
 /*

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -1119,7 +1119,7 @@ static float est_timing_and_freq(struct OFDM *ofdm,
         for(int t=0; t<Ncorr; t+=tstep) {
             complex float corr = 0;
             for(int i=0; i<Npsam; i++)
-                corr += rx[i+t]*conj(mvec[i]);
+                corr += rx[i+t]*conjf(mvec[i]);
             if (cabsf(corr) > max_corr) {
                 max_corr = cabsf(corr);
                 *t_est = t;
@@ -1131,8 +1131,8 @@ static float est_timing_and_freq(struct OFDM *ofdm,
     /* obtain normalised real number for timing_mx */
     float mag1=0, mag2=0;
     for(int i=0; i<Npsam; i++) {
-        mag1 += cabsf(known_samples[i]*conj(known_samples[i]));
-        mag2 += cabsf(rx[i+*t_est]*conj(rx[i+*t_est]));
+        mag1 += cabsf(known_samples[i]*conjf(known_samples[i]));
+        mag2 += cabsf(rx[i+*t_est]*conjf(rx[i+*t_est]));
     }
     float timing_mx = max_corr*max_corr/(mag1*mag2+1E-12);
     if (ofdm->verbose > 2) {

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -1792,7 +1792,9 @@ float ofdm_esno_est_calc(complex float *rx_sym, int nsym) {
         noise_var = sig_var;
     noise_var *= 2.0f;
     
-    return 10.0*log10(sig_var/noise_var); 
+    float EsNodB = 10.0*log10((1E-12+sig_var)/(1E-12+noise_var));
+    assert(isnan(EsNodB) == 0);
+    return EsNodB;
 }
 
 

--- a/unittest/tnewamp1.c
+++ b/unittest/tnewamp1.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[]) {
             H[f][m].real = 0.0;
             H[f][m].imag = 0.0;
         }
-        for(k=0; m<K; k++)
+        for(k=0; k<K; k++)
             interpolated_surface_[f][k] = 0.0;
         voicing_[f] = 0;
     }


### PR DESCRIPTION
Bug reported during freedv-gui testing [here](https://github.com/drowe67/freedv-gui/pull/123#issuecomment-832389359) here of squelch not opening on OFDM modes.  Traced to a `nan` in SNR.  Not repeatable on all machines.