### PR TITLE
Optimising cohspk modem

### DIFF
--- a/octave/esno_est.m
+++ b/octave/esno_est.m
@@ -126,7 +126,7 @@ function esno_est_test_c(channel="awgn")
     printf("\nRunning C version....\n");
     path_to_unittest = "../build_linux/unittest"
     if getenv("PATH_TO_UNITEST")
-      path_to_unittest_exe = getenv("PATH_TO_UNITTEST")
+      path_to_unittest = getenv("PATH_TO_UNITEST")
       printf("setting path from env var to %s\n", path_to_unittest);
     end
     system(sprintf("%s/tesno_est %s %d > tesno_est_out.txt", path_to_unittest, "esno_est.iqfloat", length(rx_syms)));

--- a/src/cohpsk.c
+++ b/src/cohpsk.c
@@ -527,17 +527,20 @@ void tx_filter_and_upconvert_coh(COMP tx_fdm[], int Nc, const COMP tx_symbols[],
 
 void corr_with_pilots(float *corr_out, float *mag_out, struct COHPSK *coh, int t, float f_fine)
 {
-    COMP  acorr, f_fine_rect, f_corr;
+    COMP  acorr, f_fine_rect[NPILOTSFRAME+2], f_corr;
     float mag, corr;
     int   c, p, pc;
+
+    for (p=0; p<NPILOTSFRAME+2; p++) {
+        f_fine_rect[p].real = cosf(f_fine*2.0*M_PI*(sampling_points[p]+1.0)/COHPSK_RS);
+        f_fine_rect[p].imag = sinf(f_fine*2.0*M_PI*(sampling_points[p]+1.0)/COHPSK_RS);
+    }
 
     corr = 0.0; mag = 0.0;
     for (c=0; c<COHPSK_NC*ND; c++) {
         acorr.real = 0.0; acorr.imag = 0.0;
         for (p=0; p<NPILOTSFRAME+2; p++) {
-            f_fine_rect.real = cosf(f_fine*2.0*M_PI*(sampling_points[p]+1.0)/COHPSK_RS);
-            f_fine_rect.imag = sinf(f_fine*2.0*M_PI*(sampling_points[p]+1.0)/COHPSK_RS);
-            f_corr = cmult(f_fine_rect, coh->ct_symb_buf[t+sampling_points[p]][c]);
+            f_corr = cmult(f_fine_rect[p], coh->ct_symb_buf[t+sampling_points[p]][c]);
             pc = c % COHPSK_NC;
             acorr = cadd(acorr, fcmult(coh->pilot2[p][pc], f_corr));
             mag  += cabsolute(f_corr);

--- a/src/cohpsk.c
+++ b/src/cohpsk.c
@@ -528,20 +528,21 @@ void tx_filter_and_upconvert_coh(COMP tx_fdm[], int Nc, const COMP tx_symbols[],
 void corr_with_pilots(float *corr_out, float *mag_out, struct COHPSK *coh, int t, float f_fine)
 {
     COMP  acorr, f_fine_rect[NPILOTSFRAME+2], f_corr;
-    float mag, corr;
+    float mag, corr, result;
+    float tau = 2.0f * M_PI;
     int   c, p, pc;
 
     for (p=0; p<NPILOTSFRAME+2; p++) {
-        f_fine_rect[p].real = cosf(f_fine*2.0*M_PI*(sampling_points[p]+1.0)/COHPSK_RS);
-        f_fine_rect[p].imag = sinf(f_fine*2.0*M_PI*(sampling_points[p]+1.0)/COHPSK_RS);
+        result = f_fine * tau * (sampling_points[p]+1.0) / COHPSK_RS;
+        f_fine_rect[p].real = cosf(result);
+        f_fine_rect[p].imag = sinf(result);
     }
 
     corr = 0.0; mag = 0.0;
     for (c=0; c<COHPSK_NC*ND; c++) {
-        acorr.real = 0.0; acorr.imag = 0.0;
+        acorr.real = 0.0f; acorr.imag = 0.0f; pc = c % COHPSK_NC;
         for (p=0; p<NPILOTSFRAME+2; p++) {
             f_corr = cmult(f_fine_rect[p], coh->ct_symb_buf[t+sampling_points[p]][c]);
-            pc = c % COHPSK_NC;
             acorr = cadd(acorr, fcmult(coh->pilot2[p][pc], f_corr));
             mag  += cabsolute(f_corr);
         }
@@ -827,10 +828,12 @@ void fdmdv_freq_shift_coh(COMP rx_fdm_fcorr[], COMP rx_fdm[], float foff, float 
 {
     COMP  foff_rect;
     float mag;
+    float tau = 2.0f * M_PI;
+    float result = tau * foff/Fs;
     int   i;
 
-    foff_rect.real = cosf(2.0*PI*foff/Fs);
-    foff_rect.imag = sinf(2.0*PI*foff/Fs);
+    foff_rect.real = cosf(result);
+    foff_rect.imag = sinf(result);
     for(i=0; i<nin; i++) {
 	*foff_phase_rect = cmult(*foff_phase_rect, foff_rect);
 	rx_fdm_fcorr[i] = cmult(rx_fdm[i], *foff_phase_rect);


### PR DESCRIPTION
Attempting to address https://github.com/drowe67/freedv-gui/issues/126

Test below was initially 9.8s, so 30% faster:

```
time ./src/freedv_rx 700C ~/freedv-gui/wav/ve9qrp_700d.wav /dev/null
frames decoded: 1404  output speech samples: 898560

real	0m6.810s
user	0m6.810s
sys	0m0.000s
```
