### PR TITLE
codec_fft.c codepath issue

### DIFF
--- a/src/codec2_fft.c
+++ b/src/codec2_fft.c
@@ -133,20 +133,18 @@ void codec2_fft_inplace(codec2_fft_cfg cfg, codec2_fft_cpx* inout)
 {
 
 #ifdef USE_KISS_FFT
-    kiss_fft_cpx in[512];
     // decide whether to use the local stack based buffer for in
     // or to allow kiss_fft to allocate RAM
     // second part is just to play safe since first method
     // is much faster and uses less RAM
-    if (cfg->nfft*sizeof(kiss_fft_cpx) <= 512)
+    if (cfg->nfft <= 512)
     {
-        fprintf(stderr, "codepath 1 nfft: %d\n",cfg->nfft );
+        kiss_fft_cpx in[512];
         memcpy(in,inout,cfg->nfft*sizeof(kiss_fft_cpx));
         kiss_fft(cfg, in, (kiss_fft_cpx*)inout);
     }
     else
     {
-        fprintf(stderr, "codepath 2 nfft: %d\n", cfg->nfft);
         kiss_fft(cfg, (kiss_fft_cpx*)inout, (kiss_fft_cpx*)inout);
     }
 #else

--- a/src/codec2_fft.c
+++ b/src/codec2_fft.c
@@ -140,11 +140,13 @@ void codec2_fft_inplace(codec2_fft_cfg cfg, codec2_fft_cpx* inout)
     // is much faster and uses less RAM
     if (cfg->nfft*sizeof(kiss_fft_cpx) <= 512)
     {
+        fprintf(stderr, "codepath 1 nfft: %d\n",cfg->nfft );
         memcpy(in,inout,cfg->nfft*sizeof(kiss_fft_cpx));
         kiss_fft(cfg, in, (kiss_fft_cpx*)inout);
     }
     else
     {
+        fprintf(stderr, "codepath 2 nfft: %d\n", cfg->nfft);
         kiss_fft(cfg, (kiss_fft_cpx*)inout, (kiss_fft_cpx*)inout);
     }
 #else


### PR DESCRIPTION
Looking into https://github.com/drowe67/codec2/issues/186, it does indeed appear that the first codepath is never taken, even though it should be for `nfft=256` or `nfft=512`:

```
ctest -V _R test_codec2
<snip>
codepath 2 nfft: 512
<snip>
codepath 2 nfft: 256
```
