### PR TITLE
SNR and Scatter not working on 2020

### DIFF
--- a/README_freedv.md
+++ b/README_freedv.md
@@ -99,18 +99,18 @@ FreeDV 2400A and FreeDV 2400B are modes designed for VHF radio. FreeDV 2400A is 
 
 Demos of FreeDV 2400A and 2400B:
 ```
-$ ./freedv_tx 2400A ../../raw/ve9qrp_10s.raw - | ./freedv_rx 2400A - - | play -t raw -r 8000 -s -2 -
-$ ./freedv_tx 2400B ../../raw/ve9qrp_10s.raw - | ./freedv_rx 2400B - - | play -t raw -r 8000 -s -2 -
+$ ./freedv_tx 2400A ../../raw/ve9qrp_10s.raw - | ./freedv_rx 2400A - - | play -t .s16 -r 8000 -
+$ ./freedv_tx 2400B ../../raw/ve9qrp_10s.raw - | ./freedv_rx 2400B - - | play -t .s16 -r 8000 -
 ```
 Note for FreeDV 2400A/2400B the modem signal sample rate is 48kHz.  To
 listen to the modem tones from FreeDV 2400B, or play them into a FM HT
 mic input:
 ```
-$ ./freedv_tx 2400B ../../raw/ve9qrp_10s.raw - | play -t raw -r 48000 -s -2 -
+$ ./freedv_tx 2400B ../../raw/ve9qrp_10s.raw - | play -t .s16 -r 48000 -
 ```
 Simulate FreeDV 2400B passing through a 300 to 3000 Hz audio path using sox to filter:
 ```
-$  ./freedv_tx 2400B ../../raw/ve9qrp_10s.raw - | sox -t raw -r 48000 -s -2 - -t raw - sinc 300-3000 | ./freedv_rx 2400B - - | play -t raw -r 8000 -s -2 -
+$  ./freedv_tx 2400B ../../raw/ve9qrp_10s.raw - | sox -t .s16 -r 48000 - -t .s16 - sinc 300-3000 | ./freedv_rx 2400B - - | play -t .s16 -r 8000 -
 ```
 
 ## FreeDV 2020 support (building with LPCNet)

--- a/src/fmfsk.c
+++ b/src/fmfsk.c
@@ -76,7 +76,7 @@ struct FMFSK * fmfsk_create(int Fs,int Rb){
         free(fmfsk);
         return NULL;
     }
-    
+    for(int i=0; i<fmfsk->nmem; i++) oldsamps[i] = 0.0;
     fmfsk->oldsamps = oldsamps;
 
     fmfsk->stats = (struct MODEM_STATS*)malloc(sizeof(struct MODEM_STATS));

--- a/src/fmfsk.c
+++ b/src/fmfsk.c
@@ -332,7 +332,7 @@ void fmfsk_demod(struct FMFSK *fmfsk, uint8_t rx_bits[],float fmfsk_in[]){
     /* Zero out all of the other things */
     fmfsk->stats->foff = 0;
 
-    /* Use moving average to smooth SNR display */
+    /* Use moving average to smooth SNR */
     var_signal += 1E-6/3.1; var_noise += 1E-6; /* prevent NAN and bias towards -5dB SNR for zero signal inputs */
     if(fmfsk->snr_mean < 0.1)
         fmfsk->snr_mean = (10.0 * log10f(var_signal / var_noise));

--- a/src/fmfsk.c
+++ b/src/fmfsk.c
@@ -333,12 +333,13 @@ void fmfsk_demod(struct FMFSK *fmfsk, uint8_t rx_bits[],float fmfsk_in[]){
     fmfsk->stats->foff = 0;
 
     /* Use moving average to smooth SNR display */
+    var_signal += 1E-6/3.1; var_noise += 1E-6; /* prevent NAN and bias towards -5dB SNR for zero signal inputs */
     if(fmfsk->snr_mean < 0.1)
         fmfsk->snr_mean = (10.0 * log10f(var_signal / var_noise));
     else
         fmfsk->snr_mean = 0.9 * fmfsk->snr_mean + 0.1 * (10.0 * log10f(var_signal / var_noise));
     fmfsk->stats->snr_est = fmfsk->snr_mean;
-        
+
     /* Collect an eye diagram */
     /* Take a sample for the eye diagrams */
     neyesamp = fmfsk->stats->neyesamp = Ts*4;

--- a/src/freedv_2020.c
+++ b/src/freedv_2020.c
@@ -186,7 +186,7 @@ int freedv_comprx_2020(struct freedv *f, COMP demod_in[]) {
     int parityCheckCount = 0;
     uint8_t rx_uw[f->ofdm_nuwbits];
 
-    f->sync = f->stats.sync = 0;
+    f->sync = 0;
 
     // TODO: should be higher for 2020?
     float EsNo = 3.0;
@@ -195,7 +195,7 @@ int freedv_comprx_2020(struct freedv *f, COMP demod_in[]) {
 
     if (ofdm->sync_state == search) {
         ofdm_sync_search(f->ofdm, demod_in);
-        f->stats.snr_est = -5.0;
+        f->snr_est = -5.0;
     }
 
     /* OK modem is in sync */

--- a/src/freedv_2020.c
+++ b/src/freedv_2020.c
@@ -195,6 +195,7 @@ int freedv_comprx_2020(struct freedv *f, COMP demod_in[]) {
 
     if (ofdm->sync_state == search) {
         ofdm_sync_search(f->ofdm, demod_in);
+        f->stats->snr_est = 0.0;
     }
 
     /* OK modem is in sync */

--- a/src/freedv_2020.c
+++ b/src/freedv_2020.c
@@ -195,7 +195,7 @@ int freedv_comprx_2020(struct freedv *f, COMP demod_in[]) {
 
     if (ofdm->sync_state == search) {
         ofdm_sync_search(f->ofdm, demod_in);
-        f->stats->snr_est = 0.0;
+        f->stats.snr_est = -5.0;
     }
 
     /* OK modem is in sync */

--- a/src/freedv_700.c
+++ b/src/freedv_700.c
@@ -412,6 +412,7 @@ int freedv_comp_short_rx_ofdm(struct freedv *f, void *demod_in_8kHz, int demod_i
             ofdm_sync_search_shorts(f->ofdm, (short*)demod_in_8kHz, new_gain);
         else
             ofdm_sync_search(f->ofdm, (COMP*)demod_in_8kHz);
+        f->stats->snr_est = 0.0;
     }
 
     if ((ofdm->sync_state == synced) || (ofdm->sync_state == trial)) {

--- a/src/freedv_700.c
+++ b/src/freedv_700.c
@@ -412,7 +412,7 @@ int freedv_comp_short_rx_ofdm(struct freedv *f, void *demod_in_8kHz, int demod_i
             ofdm_sync_search_shorts(f->ofdm, (short*)demod_in_8kHz, new_gain);
         else
             ofdm_sync_search(f->ofdm, (COMP*)demod_in_8kHz);
-        f->stats->snr_est = 0.0;
+        f->stats.snr_est = -5.0;
     }
 
     if ((ofdm->sync_state == synced) || (ofdm->sync_state == trial)) {

--- a/src/freedv_700.c
+++ b/src/freedv_700.c
@@ -400,19 +400,17 @@ int freedv_comp_short_rx_ofdm(struct freedv *f, void *demod_in_8kHz, int demod_i
 
     assert((demod_in_is_short == 0) || (demod_in_is_short == 1));
 
-    f->sync = f->stats.sync = 0;
     int rx_status = 0;
-
-    /* TODO estimate this properly from signal */
-    float EsNo = 3.0;
-
+    float EsNo = 3.0;    /* further work: estimate this properly from signal */
+    f->sync = 0;
+    
     /* looking for OFDM modem sync */
     if (ofdm->sync_state == search) {
         if (demod_in_is_short)
             ofdm_sync_search_shorts(f->ofdm, (short*)demod_in_8kHz, new_gain);
         else
             ofdm_sync_search(f->ofdm, (COMP*)demod_in_8kHz);
-        f->stats.snr_est = -5.0;
+        f->snr_est = -5.0;
     }
 
     if ((ofdm->sync_state == synced) || (ofdm->sync_state == trial)) {
@@ -520,7 +518,7 @@ int freedv_comp_short_rx_ofdm(struct freedv *f, void *demod_in_8kHz, int demod_i
 
     f->nin = ofdm_get_nin(ofdm);
     ofdm_sync_state_machine(ofdm, rx_uw);
-
+     
     int print_full = 0; int print_truncated = 0;
     if (f->verbose && ((rx_status & FREEDV_RX_BITS) || (rx_status &  FREEDV_RX_BIT_ERRORS)))
         print_full = 1;

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -1185,8 +1185,8 @@ void freedv_get_modem_stats(struct freedv *f, int *sync, float *snr_est)
         fdmdv_get_demod_stats(f->fdmdv, &f->stats);
     if (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode))
         cohpsk_get_demod_stats(f->cohpsk, &f->stats);
-    if (sync) *sync = f->stats.sync;
-    if (snr_est) *snr_est = f->stats.snr_est;
+    if (sync) *sync = f->sync;
+    if (snr_est) *snr_est = f->snr_est;
 }
 
 /*---------------------------------------------------------------------------*\
@@ -1337,7 +1337,7 @@ int freedv_get_total_bits_coded           (struct freedv *f) {return f->total_bi
 int freedv_get_total_bit_errors_coded     (struct freedv *f) {return f->total_bit_errors_coded;}
 int freedv_get_total_packets              (struct freedv *f) {return f->total_packets;}
 int freedv_get_total_packet_errors        (struct freedv *f) {return f->total_packet_errors;}
-int freedv_get_sync                       (struct freedv *f) {return f->stats.sync;}
+int freedv_get_sync                       (struct freedv *f) {return f->sync;}
 struct CODEC2 *freedv_get_codec2	        (struct freedv *f) {return  f->codec2;}
 int freedv_get_bits_per_codec_frame       (struct freedv *f) {return f->bits_per_codec_frame;}
 int freedv_get_bits_per_modem_frame       (struct freedv *f) {return f->bits_per_modem_frame;}
@@ -1387,13 +1387,13 @@ void freedv_get_modem_extended_stats(struct freedv *f, struct MODEM_STATS *stats
     if (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)) {
         fsk_get_demod_stats(f->fsk, stats);   /* eye diagram samples, clock offset etc */
         stats->snr_est = f->snr_est;          /* estimated when fsk_demod() called in freedv_fsk.c */
-        stats->sync = f->stats.sync;          /* sync indicator comes from framing layer */
+        stats->sync = f->sync;                /* sync indicator comes from framing layer */
     }
 
     if (FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)) {
         fmfsk_get_demod_stats(f->fmfsk, stats);
         stats->snr_est = f->snr_est;
-        stats->sync = f->stats.sync;
+        stats->sync = f->sync;
     }
 
     if (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode)) {
@@ -1406,7 +1406,9 @@ void freedv_get_modem_extended_stats(struct freedv *f, struct MODEM_STATS *stats
         // TODO we need a better design here: Issue #182
         size_t ncopy = (void*)stats->rx_eye - (void*)stats;
         memcpy(stats, &f->stats, ncopy);
-    }
+        stats->snr_est = f->snr_est;
+        stats->sync = f->sync;
+  }
 }
 
 int freedv_get_n_tx_preamble_modem_samples(struct freedv *f) {

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -255,7 +255,8 @@ static void codec2_encode_upacked(struct freedv *f, uint8_t unpacked_bits[], sho
 }
 
 static int is_ofdm_mode(struct freedv *f) {
-    return FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)   ||
+    return FDV_MODE_ACTIVE( FREEDV_MODE_2020, f->mode)   ||
+           FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)   ||
            FDV_MODE_ACTIVE( FREEDV_MODE_700E, f->mode)   ||
            FDV_MODE_ACTIVE( FREEDV_MODE_DATAC0, f->mode) ||
            FDV_MODE_ACTIVE( FREEDV_MODE_DATAC1, f->mode) ||

--- a/src/freedv_api_internal.h
+++ b/src/freedv_api_internal.h
@@ -69,7 +69,7 @@ struct freedv {
     struct FMFSK        *fmfsk;
     struct OFDM         *ofdm;
     struct LDPC         *ldpc;
-    struct MODEM_STATS   stats;
+    struct MODEM_STATS   stats;                 // working memory for when we call xxx_stats function for each demod
 #ifdef __LPCNET__
     struct LPCNetFreeDV *lpcnet;
 #endif
@@ -130,9 +130,9 @@ struct freedv {
     int                  tx_sync_bit;
     int                  frames;
     int                  clip_en;                            /* non-zero for modem Tx clipping to lower PAPR */
-    int                  sync;
+    int                  sync;                               /* we set this when a mode is in sync */
     int                  evenframe;
-    float                snr_est;
+    float                snr_est;                            /* we set this each time the modes's demod estimates SNR */
     float                snr_squelch_thresh;
     int                  squelch_en;
     int                  nin, nin_prev;

--- a/src/freedv_fsk.c
+++ b/src/freedv_fsk.c
@@ -584,6 +584,8 @@ int freedv_comprx_fsk(struct freedv *f, COMP demod_in[]) {
             demod_in_float[i] = demod_in[i].real;
         }
         fmfsk_demod(f->fmfsk,(uint8_t*)f->tx_bits,demod_in_float);
+        /* The fmfsk modem operates on the baseband output of an analog FM demod so the
+           mapping to SNR in 8k is hard to determine */
         f->snr_est = f->fmfsk->snr_mean;
         f->nin = fmfsk_nin(f->fmfsk);
     }
@@ -603,9 +605,9 @@ int freedv_comprx_fsk(struct freedv *f, COMP demod_in[]) {
         if( f->freedv_put_next_proto != NULL){
             (*f->freedv_put_next_proto)(f->proto_callback_state,(char*)proto_bits);
         }
-    }
-    f->sync = f->deframer->state;
-    f->stats.sync = f->deframer->state;
+        f->sync = 1;
+    } else
+        f->sync = 0;
 
     return rx_status;
 }

--- a/src/freedv_vhf_framing.c
+++ b/src/freedv_vhf_framing.c
@@ -773,8 +773,8 @@ int fvhff_deframe_bits(struct freedv_vhf_deframer * def,uint8_t codec2_out[],uin
         uw_sync_tol = 3;    /* The UW bit error tolerance for frames after sync */
         miss_tol = 4;       /* How many UWs may be missed before going into the de-synced state */
     }else if(frame_type == FREEDV_HF_FRAME_B){
-        uw_first_tol = 1;   /* The UW bit-error tolerance for the first frame */
-        uw_sync_tol = 2;    /* The UW bit error tolerance for frames after sync */
+        uw_first_tol = 0;   /* The UW bit-error tolerance for the first frame */
+        uw_sync_tol = 1;    /* The UW bit error tolerance for frames after sync */
         miss_tol = 3;       /* How many UWs may be missed before going into the de-synced state */
     }else{
         return 0;

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -2141,7 +2141,7 @@ void ofdm_get_demod_stats(struct OFDM *ofdm, struct MODEM_STATS *stats, complex 
         /* no smoothing as we have a large number of symbols per packet */
         stats->snr_est = SNR3kdB;
     else {        
-        /* in voice modes we furrther smloth SNR est, fast attack, slow decay */
+        /* in voice modes we further smooth SNR est, fast attack, slow decay */
         if (SNR3kdB > stats->snr_est)
             stats->snr_est = SNR3kdB;
         else


### PR DESCRIPTION
Hi @tmiw - thanks for reporting this.  As per https://github.com/drowe67/codec2/issues/182 - this general area of the FreeDV API (stats reporting/SNR/squelch) has been problematic in the past which suggests some more refactoring/design review is required.  Still thinking about the best way forward :thinking: 

Changes made:
1. Hooked up 2020 to new OFDM stats reporting logic, which fixed OP issue.
2. Secondary issue: OFDM modes now reset SNR to -5dB when out of sync, it was previously frozen as `modem_stats` are not updated when out of sync.

I tried full duplex 2020 with an ALSA loopback device and it worked OK.

Further work - test the OFDM modes (700D/E/2020) on air with some real QSOs, make sure squelch/SNR is working correctly.  The changes so far have been tested with the `freedv-gui/wav` demo files which don't have any noise.