### PR TITLE
FreeDV 700E and codec 2 equaliser

### DIFF
--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -1250,7 +1250,7 @@ void freedv_set_phase_est_bandwidth_mode(struct freedv *f, int val) {
 }
 
 void freedv_set_eq(struct freedv *f, int val) {
-    if (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700E, f->mode)) {
         codec2_700c_eq(f->codec2, val);
     }
 }

--- a/src/freedv_tx.c
+++ b/src/freedv_tx.c
@@ -119,7 +119,8 @@ int main(int argc, char *argv[]) {
     freedv_set_tx_bpf(freedv, use_txbpf);
     freedv_set_dpsk(freedv, use_dpsk);
     freedv_set_verbose(freedv, 1);
-
+    freedv_set_eq(freedv, 1); /* for 700C/D/E */
+    
     /* set up callback for txt msg chars */
     struct my_callback_state  my_cb_state;
     sprintf(my_cb_state.tx_str, "cq cq cq hello world\r");


### PR DESCRIPTION
While working on https://github.com/drowe67/codec2/pull/193 I discovered the automatic mic equaliser was not being switched on for FreeDV 700E - Ouch!

This would be lowering the speech quality for freedv-gui users on 700E compared to 700C/D, as the Tools-Filter-Auto EQ check box would have been doing nothing for 700E.  I've also made sure the EQ is on by default when using the command line `freedv_tx` tool.

![Screenshot from 2021-06-19 09-38-45](https://user-images.githubusercontent.com/45574645/122625070-5d36f080-d0e2-11eb-88cb-1f3d3a059222.png)

You can tell if the Auto EQ is working by:
1. Set up freedv-gui with a loopback sound device/full duplex.
1. Start freedv-gui and Tx
1. Tx a canned speech file Tools - Start Play File Mic In, check loop.
1. Monitor the stats window/Var field while toggling Tools-Filter-Auto EQ.  I get about 18 with Auto EQ off, about 10 with it on.  Toggling Auto EQ also resets the variance (spectral distortion) estimator.