### PR TITLE
Remove assert from freedv_set_carrier_ampl().

### DIFF
--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -1272,10 +1272,11 @@ void freedv_set_callback_error_pattern(struct freedv *f, freedv_calback_error_pa
 }
 
 void freedv_set_carrier_ampl(struct freedv *f, int c, float ampl) {
-    assert(FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode));
-    cohpsk_set_carrier_ampl(f->cohpsk, c, ampl);
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode))
+    {
+        cohpsk_set_carrier_ampl(f->cohpsk, c, ampl);
+    }
 }
-
 
 /*---------------------------------------------------------------------------* \
 


### PR DESCRIPTION
Per drowe67/freedv-gui#140, this downgrades the assertion in freedv_set_carrier_ampl() to a no-op if the mode is not 700C.