### PR TITLE
Bump codec2 to 1.0.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,11 @@ endif("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
 # Set project version information. This should probably be done via external
 # file at some point.
 #
-set(CODEC2_VERSION_MAJOR 0)
-set(CODEC2_VERSION_MINOR 9)
+set(CODEC2_VERSION_MAJOR 1)
+set(CODEC2_VERSION_MINOR 0)
 # Set to patch level if needed, otherwise leave FALSE.
 # Must be positive (non-zero) if set, since 0 == FALSE in CMake.
-set(CODEC2_VERSION_PATCH 2)
+set(CODEC2_VERSION_PATCH 0)
 set(CODEC2_VERSION "${CODEC2_VERSION_MAJOR}.${CODEC2_VERSION_MINOR}")
 # Patch level version bumps should not change API/ABI.
 set(SOVERSION "${CODEC2_VERSION_MAJOR}.${CODEC2_VERSION_MINOR}")
@@ -88,6 +88,12 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/.git)
 else()
         add_definitions(-DGIT_HASH="None")
 endif()
+
+set(ARCHIVE_NAME "codec2-${CODEC2_VERSION_MAJOR}.${CODEC2_VERSION_MINOR}.${CODEC2_VERSION_PATCH}")
+add_custom_target(dist
+    COMMAND git archive --prefix=${ARCHIVE_NAME}/ HEAD
+        | bzip2 > ${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}.tar.bz2
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 # Set default C flags.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-strict-overflow")


### PR DESCRIPTION
Bumps version number of Codec2 to 1.0.0 and includes "make dist" changes from https://github.com/drowe67/freedv-gui/pull/152.