### PR TITLE
Add 700E support to the SM1000.

### DIFF
--- a/src/freedv_700.c
+++ b/src/freedv_700.c
@@ -110,7 +110,7 @@ void freedv_ofdm_voice_open(struct freedv *f, char *mode) {
     ofdm_config = ofdm_get_config_param(f->ofdm);
     f->ofdm_bitsperpacket = ofdm_get_bits_per_packet(f->ofdm);
     f->ofdm_bitsperframe = ofdm_get_bits_per_frame(f->ofdm);
-    f->ofdm_nuwbits = (ofdm_config->ns - 1) * ofdm_config->bps - ofdm_config->txtbits;
+    f->ofdm_nuwbits = ofdm_config->nuwbits;
     f->ofdm_ntxtbits = ofdm_config->txtbits;
 
     f->ldpc = (struct LDPC*)MALLOC(sizeof(struct LDPC));

--- a/src/freedv_700.c
+++ b/src/freedv_700.c
@@ -140,9 +140,10 @@ void freedv_ofdm_voice_open(struct freedv *f, char *mode) {
 
     f->tx_bits = NULL; /* not used for 700D */
 
-    /* tx BPF off on embedded platforms, as it consumes significant CPU */
+    /* tx BPF off on embedded platforms for 700D, as it consumes significant CPU */
 #ifdef __EMBEDDED__
-    ofdm_set_tx_bpf(f->ofdm, 0);
+    if (strcmp(mode, "700E") != 0)
+        ofdm_set_tx_bpf(f->ofdm, 0);
 #endif
 
     f->speech_sample_rate = FREEDV_FS_8000;

--- a/src/freedv_700.c
+++ b/src/freedv_700.c
@@ -163,6 +163,9 @@ void freedv_ofdm_voice_open(struct freedv *f, char *mode) {
     
     /* attenuate audio 12dB as channel noise isn't that pleasant */
     f->passthrough_gain = 0.25;
+    
+    /* nuwbits is dependent on ns, bps and txtbits. */
+    assert((ofdm_config->ns - 1) * ofdm_config->bps - ofdm_config->txtbits == f->ofdm_nuwbits);
 }
 
 // open function for OFDM data modes, TODO consider moving to a new

--- a/src/freedv_700.c
+++ b/src/freedv_700.c
@@ -140,12 +140,6 @@ void freedv_ofdm_voice_open(struct freedv *f, char *mode) {
 
     f->tx_bits = NULL; /* not used for 700D */
 
-    /* tx BPF off on embedded platforms for 700D, as it consumes significant CPU */
-#ifdef __EMBEDDED__
-    if (strcmp(mode, "700E") != 0)
-        ofdm_set_tx_bpf(f->ofdm, 0);
-#endif
-
     f->speech_sample_rate = FREEDV_FS_8000;
     f->codec2 = codec2_create(CODEC2_MODE_700C); assert(f->codec2 != NULL);
     /* should be exactly an integer number of Codec 2 frames in a OFDM modem frame */

--- a/src/freedv_700.c
+++ b/src/freedv_700.c
@@ -163,9 +163,10 @@ void freedv_ofdm_voice_open(struct freedv *f, char *mode) {
     
     /* attenuate audio 12dB as channel noise isn't that pleasant */
     f->passthrough_gain = 0.25;
-    
-    /* nuwbits is dependent on ns, bps and txtbits. */
-    //assert((ofdm_config->ns - 1) * ofdm_config->bps - ofdm_config->txtbits == f->ofdm_nuwbits);
+
+    /* should all add up to a complete frame */
+    assert((ofdm_config->ns - 1) * ofdm_config->nc * ofdm_config->bps ==
+	   f->ldpc->coded_bits_per_frame + ofdm_config->txtbits + f->ofdm_nuwbits);
 }
 
 // open function for OFDM data modes, TODO consider moving to a new

--- a/src/freedv_700.c
+++ b/src/freedv_700.c
@@ -165,7 +165,7 @@ void freedv_ofdm_voice_open(struct freedv *f, char *mode) {
     f->passthrough_gain = 0.25;
     
     /* nuwbits is dependent on ns, bps and txtbits. */
-    assert((ofdm_config->ns - 1) * ofdm_config->bps - ofdm_config->txtbits == f->ofdm_nuwbits);
+    //assert((ofdm_config->ns - 1) * ofdm_config->bps - ofdm_config->txtbits == f->ofdm_nuwbits);
 }
 
 // open function for OFDM data modes, TODO consider moving to a new

--- a/src/ldpc_codes.c
+++ b/src/ldpc_codes.c
@@ -39,7 +39,6 @@ struct LDPC ldpc_codes[] = {
         (uint16_t *)HRA_112_112_H_rows,
         (uint16_t *)HRA_112_112_H_cols
     }
-    #ifndef __EMBEDDED__
     ,
     /* short rate 1/2 code for FreeDV 700E */
     {
@@ -56,6 +55,7 @@ struct LDPC ldpc_codes[] = {
         (uint16_t *)HRA_56_56_H_rows,
         (uint16_t *)HRA_56_56_H_cols
     },
+    #ifndef __EMBEDDED__
 
     /* default Wenet High Alitiude Balloon rate 0.8 code */
     {

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -223,6 +223,7 @@ struct OFDM *ofdm_create(const struct OFDM_CONFIG *config) {
     } else {
         /* Use the users values */
 
+
         strcpy(ofdm->mode, config->mode);
         ofdm->nc = config->nc;                    /* Number of carriers */
         ofdm->np = config->np;                    /* Number of modem Frames per Packet */
@@ -251,6 +252,7 @@ struct OFDM *ofdm_create(const struct OFDM_CONFIG *config) {
         ofdm->clip_en = config->clip_en;
         memcpy(ofdm->tx_uw, config->tx_uw, ofdm->nuwbits);
         ofdm->data_mode = config->data_mode;
+
     }
 
     ofdm->rs = (1.0f / ofdm->ts);                 /* Modulation Symbol Rate */

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -1918,17 +1918,15 @@ void ofdm_sync_state_machine_data_streaming(struct OFDM *ofdm, uint8_t *rx_uw) {
     }
 
     if (ofdm->sync_state == trial) {
-        if (ofdm->sync_state == trial) {
-            if (ofdm->uw_errors < ofdm->bad_uw_errors) {
-                next_state = synced;
-                ofdm->packet_count = 0;
-                ofdm->modem_frame = ofdm->nuwframes;
-            } else {
-                ofdm->sync_counter++;
+        if (ofdm->uw_errors < ofdm->bad_uw_errors) {
+            next_state = synced;
+            ofdm->packet_count = 0;
+            ofdm->modem_frame = ofdm->nuwframes;
+        } else {
+            ofdm->sync_counter++;
 
-                if (ofdm->sync_counter > ofdm->np) {
-                    next_state = search;
-                }
+            if (ofdm->sync_counter > ofdm->np) {
+                next_state = search;
             }
         }
     }

--- a/src/ofdm_mode.c
+++ b/src/ofdm_mode.c
@@ -52,7 +52,7 @@ void ofdm_init_mode(char mode[], struct OFDM_CONFIG *config) {
     } else if (strcmp(mode,"700E") == 0) {
          config->ts = 0.014;  config->tcp = 0.006; config->nc = 21; config->ns=4;
          config->edge_pilots = 0;
-         config->nuwbits = 12; config->bad_uw_errors = 3; config->txtbits = 2;
+         config->nuwbits = 6; config->bad_uw_errors = 3; config->txtbits = 2;
          config->state_machine = "voice2"; config->amp_est_mode = 1;
          config->ftwindowwidth = 80;
          config->codename = "HRA_56_56"; config->tx_bpf_en = false;

--- a/src/ofdm_mode.c
+++ b/src/ofdm_mode.c
@@ -52,7 +52,7 @@ void ofdm_init_mode(char mode[], struct OFDM_CONFIG *config) {
     } else if (strcmp(mode,"700E") == 0) {
          config->ts = 0.014;  config->tcp = 0.006; config->nc = 21; config->ns=4;
          config->edge_pilots = 0;
-         config->nuwbits = 6; config->bad_uw_errors = 3; config->txtbits = 2;
+         config->nuwbits = 4; config->bad_uw_errors = 3; config->txtbits = 2;
          config->state_machine = "voice2"; config->amp_est_mode = 1;
          config->ftwindowwidth = 80;
          config->codename = "HRA_56_56"; config->tx_bpf_en = false;

--- a/src/ofdm_mode.c
+++ b/src/ofdm_mode.c
@@ -52,7 +52,7 @@ void ofdm_init_mode(char mode[], struct OFDM_CONFIG *config) {
     } else if (strcmp(mode,"700E") == 0) {
          config->ts = 0.014;  config->tcp = 0.006; config->nc = 21; config->ns=4;
          config->edge_pilots = 0;
-         config->nuwbits = 4; config->bad_uw_errors = 3; config->txtbits = 2;
+         config->nuwbits = 12; config->bad_uw_errors = 3; config->txtbits = 2;
          config->state_machine = "voice2"; config->amp_est_mode = 1;
          config->ftwindowwidth = 80;
          config->codename = "HRA_56_56"; config->tx_bpf_en = false;

--- a/stm32/CMakeLists.txt
+++ b/stm32/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -std=gnu11 -mlittle-endian -mthumb -mthumb-interwork --specs=nano.specs -u_printf_float -mcpu=cortex-m4 -ffunction-sections -fdata-sections -O3")
 
 add_definitions(-DSTM32F40_41xxx -DCORTEX_M4 -D__EMBEDDED__)
-add_definitions(-DFREEDV_MODE_EN_DEFAULT=0 -DFREEDV_MODE_1600_EN=1 -DFREEDV_MODE_700D_EN=1 -DCODEC2_MODE_EN_DEFAULT=0 -DCODEC2_MODE_1300_EN=1 -DCODEC2_MODE_700C_EN=1)
+add_definitions(-DFREEDV_MODE_EN_DEFAULT=0 -DFREEDV_MODE_1600_EN=1 -DFREEDV_MODE_700D_EN=1 -DFREEDV_MODE_700E_EN=1 -DCODEC2_MODE_EN_DEFAULT=0 -DCODEC2_MODE_1300_EN=1 -DCODEC2_MODE_700C_EN=1)
 
 if(FLOAT_TYPE STREQUAL "hard")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsingle-precision-constant -Wdouble-promotion -mfpu=fpv4-sp-d16 -mfloat-abi=hard -D__FPU_PRESENT=1 -D__FPU_USED=1")
@@ -203,6 +203,7 @@ ${CODEC2_SRC}/freedv_data_channel.c
 ${CODEC2_SRC}/newamp1.c
 ${CODEC2_SRC}/mbest.c
 ${CODEC2_SRC}/HRA_112_112.c
+${CODEC2_SRC}/HRA_56_56.c
 ${CODEC2_SRC}/linreg.c
 ${CODEC2_SRC}/mpdecode_core.c
 ${CODEC2_SRC}/ldpc_codes.c

--- a/stm32/doc/sm1000_manual.md
+++ b/stm32/doc/sm1000_manual.md
@@ -9,7 +9,8 @@
 1. The SELECT button steps through the mode:
    + Analog pass through (ANA)
    + FreeDV 1600 (1600)
-   + FreeDV 700D  (700D)
+   + FreeDV 700D (700D)
+   + FreeDV 700E (700E)
 
 1. Select 1600 mode.
   
@@ -78,7 +79,8 @@ The menu structure looks like this:
         |---> "MODE": Boot-up Operating mode
         |       |---> "ANA":    Analogue mode
         |       |---> "1600":   FreeDV 1600
-        |       '---> "700D":   FreeDV 700D
+        |       |---> "700D":   FreeDV 700D
+        |       '---> "700E":   FreeDV 700E
         |
         |---> "TOT": Time-out timer
         |       |---> "TIME":   Total time-out period (0 == disabled)

--- a/stm32/doc/sm1000_manual.md
+++ b/stm32/doc/sm1000_manual.md
@@ -106,7 +106,7 @@ You can program the flash memory on your SM1000 via USB using a Windows or Linux
    2   | July 2019 | [sm1000v2.bin](http://www.rowetel.com/downloads/codec2/smartmic/sm1000v2.bin) |  [sm1000v2.dfu](http://www.rowetel.com/downloads/codec2/smartmic/sm1000v2.dfu) | FreeDV 700D and morse menus
    3   | March 2020 | [sm1000v3.bin](http://www.rowetel.com/downloads/codec2/smartmic/sm1000v3.bin) |  [sm1000v3.dfu](http://www.rowetel.com/downloads/codec2/smartmic/sm1000v3.dfu) | Menu bug fixes, 700D modem improvements & automatic Mic EQ
    4   | May 2020 | [sm1000v4.bin](http://www.rowetel.com/downloads/codec2/smartmic/sm1000v4.bin) |  [sm1000v4.dfu](http://www.rowetel.com/downloads/codec2/smartmic/sm1000v4.dfu) | 700D sync logic to reduce stop burbling with no signal
-   5   | August 2021 | [sm1000v5.bin](http://www.rowetel.com/downloads/codec2/smartmic/sm1000v5.bin) |  [sm1000v5.dfu](http://www.rowetel.com/downloads/codec2/smartmic/sm1000v5.dfu) | maintenance release due to FreeDV API refactoring, no changes to SM1000 behaivour
+   5   | August 2021 | [sm1000v5.bin](http://www.rowetel.com/downloads/codec2/smartmic/sm1000v5.bin) |  [sm1000v5.dfu](http://www.rowetel.com/downloads/codec2/smartmic/sm1000v5.dfu) | FreeDV 700E and Tx band pass filter for 700D & E
    
 ## Windows
 
@@ -176,7 +176,7 @@ To perform a factory reset, hold down BACK whilst powering the device on. A loud
 
 The SM1000 hardware was developed by David Rowe VK5DGR and Rick Barnich KA8BMA. It is being manufactured, tested and shipped by our good friend Edwin at Dragino in Shenzhen, China.
 
-Steve (K5OKC) helped develop the fine OFDM modem used for FreeDV 700D. Don (W7DMR), spearheaded the port of FreeDV 700D to the SM1000, including code optimisation and a comprehensive unit test system.  Don, Danilo (DB4PLE), and Richard (KF5OIM) have done some fantastic work on the cmake build and test system for the stm32 port of 700D. Stuart VK4MSL developed the morse menu system for the SM1000.
+Steve (K5OKC) helped develop the fine OFDM modem used for FreeDV 700D. Don (W7DMR), spearheaded the port of FreeDV 700D to the SM1000, including code optimisation and a comprehensive unit test system.  Don, Danilo (DB4PLE), and Richard (KF5OIM) have done some fantastic work on the cmake build and test system for the stm32 port of 700D. Stuart VK4MSL developed the morse menu system for the SM1000.  Mooneer, K6AQ, ported FreeDV 700E to the SM1000.
 
 Thanks also to the many Hams who kindly helped out with testing new firmware releases.
 

--- a/stm32/src/sm1000_main.c
+++ b/stm32/src/sm1000_main.c
@@ -755,7 +755,12 @@ int process_core_state_machine(int core_state, struct menu_t *menu, int *op_mode
                     mode_changed = 1;
                 } else if (switch_released(&sw_back)) {
                     /* Shortcut: change current mode */
-                    *op_mode = (*op_mode - 1) % MAX_MODES;
+                    *op_mode = *op_mode - 1;
+                    if (*op_mode < 0)
+                    {
+                        // Loop back around to the end of the mode list if we reach 0.
+                        *op_mode = MAX_MODES - 1;
+                    }
                     mode_changed = 1;
                 }
 
@@ -940,7 +945,11 @@ static void menu_default_cb(struct menu_t* const menu, uint32_t event)
             break;
         case MENU_EVT_PREV:
             sfx_play(&sfx_player, sound_click);
-            menu->current = (menu->current - 1) % item->num_children;
+            menu->current = menu->current - 1;
+            if (menu->current < 0)
+            {
+                menu->current = item->num_children - 1;
+            }
             announce = 1;
             break;
         case MENU_EVT_SELECT:
@@ -1072,7 +1081,11 @@ static void menu_op_mode_cb(struct menu_t* const menu, uint32_t event)
             break;
         case MENU_EVT_PREV:
             sfx_play(&sfx_player, sound_click);
-            menu->current = (menu->current - 1) % item->num_children;
+            menu->current = menu->current - 1;
+            if (menu->current < 0)
+            {
+                menu->current = item->num_children - 1;
+            }
             announce = 1;
             break;
         case MENU_EVT_SELECT:

--- a/stm32/src/sm1000_main.c
+++ b/stm32/src/sm1000_main.c
@@ -305,6 +305,11 @@ struct freedv *set_freedv_mode(int op_mode, int *n_samples) {
         freedv_set_snr_squelch_thresh(f, -2.0);  /* squelch at -2.0 dB      */
         freedv_set_squelch_en(f, 1);
         freedv_set_eq(f, 1);                     /* equaliser on by default */
+        
+        /* Clipping and TXBPF nice to have for 700D. */
+        freedv_set_clip(f, 1);
+        freedv_set_tx_bpf(f, 1);
+        
         *n_samples = freedv_get_n_speech_samples(f);
         break;
     case DV700E:

--- a/stm32/src/sm1000_main.c
+++ b/stm32/src/sm1000_main.c
@@ -314,6 +314,11 @@ struct freedv *set_freedv_mode(int op_mode, int *n_samples) {
         freedv_set_snr_squelch_thresh(f, 0.0);  /* squelch at 0.0 dB      */
         freedv_set_squelch_en(f, 1);
         freedv_set_eq(f, 1);                     /* equaliser on by default */
+
+        /* Clipping and TXBPF needed for 700E. */
+        freedv_set_clip(f, 1);
+        freedv_set_tx_bpf(f, 1);
+
         *n_samples = freedv_get_n_speech_samples(f);
         break;
     }

--- a/stm32/src/sm1000_main.c
+++ b/stm32/src/sm1000_main.c
@@ -945,10 +945,13 @@ static void menu_default_cb(struct menu_t* const menu, uint32_t event)
             break;
         case MENU_EVT_PREV:
             sfx_play(&sfx_player, sound_click);
-            menu->current = menu->current - 1;
-            if (menu->current < 0)
+            if (menu->current == 0)
             {
                 menu->current = item->num_children - 1;
+            }
+            else
+            {
+                menu->current = menu->current - 1;
             }
             announce = 1;
             break;
@@ -1002,7 +1005,7 @@ static const struct menu_item_t menu_op_mode = {
     .label          = "MODE",
     .event_cb       = menu_op_mode_cb,
     .children       = menu_op_mode_children,
-    .num_children   = 3,
+    .num_children   = 4,
 };
 /* Children */
 static const struct menu_item_t menu_op_mode_analog = {
@@ -1081,10 +1084,13 @@ static void menu_op_mode_cb(struct menu_t* const menu, uint32_t event)
             break;
         case MENU_EVT_PREV:
             sfx_play(&sfx_player, sound_click);
-            menu->current = menu->current - 1;
-            if (menu->current < 0)
+            if (menu->current == 0)
             {
                 menu->current = item->num_children - 1;
+            }
+            else
+            {
+                menu->current = menu->current - 1;
             }
             announce = 1;
             break;

--- a/stm32/unittest/scripts/tst_api_demod_check
+++ b/stm32/unittest/scripts/tst_api_demod_check
@@ -75,8 +75,8 @@ case "${TEST_OPT}" in
      	fi
 
 	echo "Check target decode"
-	uber_target=$(cat ref_gen.log | sed -n "s/^BER.*: \([0-9..]*\).*Tbits.*/\1/p")
-	cber_target=$(cat ref_gen.log | sed -n "s/^Coded BER.*: \([0-9..]*\).*Tbits.*/\1/p")
+	uber_target=$(cat stderr.log | sed -n "s/^BER.*: \([0-9..]*\).*Tbits.*/\1/p")
+	cber_target=$(cat stderr.log | sed -n "s/^Coded BER.*: \([0-9..]*\).*Tbits.*/\1/p")
 	printf "TARGET uncoded BER: %f coded BER: %f\n" $uber_target $cber_target
 	python -c "import sys; sys.exit(1) if $uber_target < 0.1 and abs($cber_ref-$cber_target) < 0.01 else sys.exit(0)"
 	if [[ $? -eq 1 ]]; then echo "OK"; 
@@ -152,8 +152,8 @@ case "${TEST_OPT}" in
      	fi
 
 	echo "Check target decode"
-	uber_target=$(cat ref_gen.log | sed -n "s/^BER.*: \([0-9..]*\).*Tbits.*/\1/p")
-	cber_target=$(cat ref_gen.log | sed -n "s/^Coded BER.*: \([0-9..]*\).*Tbits.*/\1/p")
+	uber_target=$(cat stderr.log | sed -n "s/^BER.*: \([0-9..]*\).*Tbits.*/\1/p")
+	cber_target=$(cat stderr.log | sed -n "s/^Coded BER.*: \([0-9..]*\).*Tbits.*/\1/p")
 	printf "TARGET uncoded BER: %f coded BER: %f\n" $uber_target $cber_target
 	python -c "import sys; sys.exit(1) if $uber_target < 0.1 and abs($cber_ref-$cber_target) < 0.01 else sys.exit(0)"
 	if [[ $? -eq 1 ]]; then echo "OK"; 

--- a/stm32/unittest/scripts/tst_api_demod_check
+++ b/stm32/unittest/scripts/tst_api_demod_check
@@ -68,7 +68,7 @@ case "${TEST_OPT}" in
 	# for such a short test, so we'll just sanity check the
 	# reference uncoded BER here. Bash can't compare floats
 	# .... so use return code of some python script
-	python -c "import sys; sys.exit(1) if $uber_ref<0.1 else sys.exit(0)"
+	python -c "import sys; sys.exit(1) if $uber_ref < 0.1 else sys.exit(0)"
 	if [[ $? -eq 1 ]]; then echo "OK"; 
 	else echo "BAD"; 
      	    let Fails=($Fails + 1)
@@ -78,7 +78,7 @@ case "${TEST_OPT}" in
 	uber_target=$(cat ref_gen.log | sed -n "s/^BER.* \([0-9..]*\) Tbits.*/\1/p")
 	cber_target=$(cat ref_gen.log | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
 	printf "TARGET uncoded BER: %f coded BER: %f\n" $uber_target $cber_target
-	python -c "import sys; sys.exit(1) if $uber_target<0.1 and abs($cber_ref-$cber_target)<0.01 else sys.exit(0)"
+	python -c "import sys; sys.exit(1) if $uber_target < 0.1 and abs($cber_ref-$cber_target) < 0.01 else sys.exit(0)"
 	if [[ $? -eq 1 ]]; then echo "OK"; 
 	else echo "BAD"; 
      	    let Fails=($Fails + 1)
@@ -145,7 +145,7 @@ case "${TEST_OPT}" in
 	# for such a short test, so we'll just sanity check the
 	# reference uncoded BER here. Bash can't compare floats
 	# .... so use return code of some python script
-	python -c "import sys; sys.exit(1) if $uber_ref<0.1 else sys.exit(0)"
+	python -c "import sys; sys.exit(1) if $uber_ref < 0.1 else sys.exit(0)"
 	if [[ $? -eq 1 ]]; then echo "OK"; 
 	else echo "BAD"; 
      	    let Fails=($Fails + 1)
@@ -155,7 +155,7 @@ case "${TEST_OPT}" in
 	uber_target=$(cat ref_gen.log | sed -n "s/^BER.* \([0-9..]*\) Tbits.*/\1/p")
 	cber_target=$(cat ref_gen.log | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
 	printf "TARGET uncoded BER: %f coded BER: %f\n" $uber_target $cber_target
-	python -c "import sys; sys.exit(1) if $uber_target<0.1 and abs($cber_ref-$cber_target)<0.01 else sys.exit(0)"
+	python -c "import sys; sys.exit(1) if $uber_target < 0.1 and abs($cber_ref-$cber_target) < 0.01 else sys.exit(0)"
 	if [[ $? -eq 1 ]]; then echo "OK"; 
 	else echo "BAD"; 
      	    let Fails=($Fails + 1)

--- a/stm32/unittest/scripts/tst_api_demod_check
+++ b/stm32/unittest/scripts/tst_api_demod_check
@@ -117,6 +117,83 @@ case "${TEST_OPT}" in
 
 	;;
 
+    700E_plain_test)
+    echo "Check reference decode"
+    p1=$(grep '^BER\.*: 0.000' ref_gen.log | wc -l)
+    p2=$(grep '^Coded BER: 0.000' ref_gen.log | wc -l)
+    if [[ $p1 -eq 1 && $p2 -eq 1 ]]; then echo "OK"; 
+    else echo "BAD"; 
+     	    let Fails=($Fails + 1)
+     	fi
+    #
+    echo "Check target decode"
+    p1=$(grep '^BER\.*: 0.000' stderr.log | wc -l)
+    p2=$(grep '^Coded BER: 0.000' stderr.log | wc -l)
+    if [[ $p1 -eq 1 && $p2 -eq 1 ]]; then echo "OK"; 
+    else echo "BAD"; 
+     	    let Fails=($Fails + 1)
+     	fi
+    ;;
+
+    700E_AWGN_test)
+    echo "Check reference decode"
+    uber_ref=$(cat ref_gen.log | sed -n "s/^BER.* \([0-9..]*\) Tbits.*/\1/p")
+    cber_ref=$(cat ref_gen.log | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
+    printf "REF   uncoded BER: %f coded BER: %f\n" $uber_ref $cber_ref
+
+    # As per notes in tst_api_demod_setup, coded BER is unreliable
+    # for such a short test, so we'll just sanity check the
+    # reference uncoded BER here. Bash can't compare floats
+    # .... so use return code of some python script
+    python -c "import sys; sys.exit(1) if $uber_ref<0.1 else sys.exit(0)"
+    if [[ $? -eq 1 ]]; then echo "OK"; 
+    else echo "BAD"; 
+     	    let Fails=($Fails + 1)
+     	fi
+
+    echo "Check target decode"
+    uber_target=$(cat ref_gen.log | sed -n "s/^BER.* \([0-9..]*\) Tbits.*/\1/p")
+    cber_target=$(cat ref_gen.log | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
+    printf "TARGET uncoded BER: %f coded BER: %f\n" $uber_target $cber_target
+    python -c "import sys; sys.exit(1) if $uber_target<0.1 and abs($cber_ref-$cber_target)<0.01 else sys.exit(0)"
+    if [[ $? -eq 1 ]]; then echo "OK"; 
+    else echo "BAD"; 
+     	    let Fails=($Fails + 1)
+     	fi
+    ;;
+
+    700E_AWGN_codec)
+    # 1/ The two output files sound OK, and when plotted look very
+    #    similar, but they don't match on a sample-sample basis.
+
+    # 2/ Suspect some small state difference, or perhaps random
+    #    number generator diverging, sampling codec2_rand() at the
+    #    end of the x86 and stm32 test programs might show up any
+    #    differences.
+
+    # 3/ At this stage - we can't make sample by sample automatic
+    #    tests work.  However there is value in running the test
+    #    to ensure no asserts are hit and the code doesn't crash
+    #    (e.g. due to an out of memory issues). A simple energy
+    #    comparison is used on the output speech files, which
+    #    will trap any large errors.
+
+    # 4/ We can also manually evaulate the ouput decoded speech by
+    #    listening to the output speech files.
+
+    compare_energy;
+
+    # make sure execution time stays within bounds
+    execution_time=mktmp
+    cat stdout.log | sed  -n "s/.*freedv_rx \([0-9..]*\) msecs/\1/p" > $execution_time
+    python -c "import sys; import numpy as np;  x=np.loadtxt(\"$execution_time\"); print(\"execution time max:: %5.2f mean: %5.2f ms\" % (np.max(x), np.mean(x))); sys.exit(1) if np.max(x) < 80.0 else sys.exit(0)"
+    if [[ $? -eq 1 ]]; then echo "execution time OK"; 
+        else echo "BAD"; 
+     	   let Fails=($Fails + 1)
+        fi
+
+    ;;
+
     1600_plain_codec)
 	compare_energy;
 	;;

--- a/stm32/unittest/scripts/tst_api_demod_check
+++ b/stm32/unittest/scripts/tst_api_demod_check
@@ -60,8 +60,8 @@ case "${TEST_OPT}" in
 
     700D_AWGN_test)
 	echo "Check reference decode"
-	uber_ref=$(cat ref_gen.log | sed -n "s/^BER.* \([0-9..]*\) Tbits.*/\1/p")
-	cber_ref=$(cat ref_gen.log | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
+	uber_ref=$(cat ref_gen.log | sed -n "s/^BER.*: \([0-9..]*\).*Tbits.*/\1/p")
+	cber_ref=$(cat ref_gen.log | sed -n "s/^Coded BER.*: \([0-9..]*\).*Tbits.*/\1/p")
 	printf "REF   uncoded BER: %f coded BER: %f\n" $uber_ref $cber_ref
 
 	# As per notes in tst_api_demod_setup, coded BER is unreliable
@@ -75,8 +75,8 @@ case "${TEST_OPT}" in
      	fi
 
 	echo "Check target decode"
-	uber_target=$(cat ref_gen.log | sed -n "s/^BER.* \([0-9..]*\) Tbits.*/\1/p")
-	cber_target=$(cat ref_gen.log | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
+	uber_target=$(cat ref_gen.log | sed -n "s/^BER.*: \([0-9..]*\).*Tbits.*/\1/p")
+	cber_target=$(cat ref_gen.log | sed -n "s/^Coded BER.*: \([0-9..]*\).*Tbits.*/\1/p")
 	printf "TARGET uncoded BER: %f coded BER: %f\n" $uber_target $cber_target
 	python -c "import sys; sys.exit(1) if $uber_target < 0.1 and abs($cber_ref-$cber_target) < 0.01 else sys.exit(0)"
 	if [[ $? -eq 1 ]]; then echo "OK"; 
@@ -137,8 +137,8 @@ case "${TEST_OPT}" in
 
     700E_AWGN_test)
 	echo "Check reference decode"
-	uber_ref=$(cat ref_gen.log | sed -n "s/^BER.* \([0-9..]*\) Tbits.*/\1/p")
-	cber_ref=$(cat ref_gen.log | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
+	uber_ref=$(cat ref_gen.log | sed -n "s/^BER.*: \([0-9..]*\).*Tbits.*/\1/p")
+	cber_ref=$(cat ref_gen.log | sed -n "s/^Coded BER.*: \([0-9..]*\).*Tbits.*/\1/p")
 	printf "REF   uncoded BER: %f coded BER: %f\n" $uber_ref $cber_ref
 
 	# As per notes in tst_api_demod_setup, coded BER is unreliable
@@ -152,8 +152,8 @@ case "${TEST_OPT}" in
      	fi
 
 	echo "Check target decode"
-	uber_target=$(cat ref_gen.log | sed -n "s/^BER.* \([0-9..]*\) Tbits.*/\1/p")
-	cber_target=$(cat ref_gen.log | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
+	uber_target=$(cat ref_gen.log | sed -n "s/^BER.*: \([0-9..]*\).*Tbits.*/\1/p")
+	cber_target=$(cat ref_gen.log | sed -n "s/^Coded BER.*: \([0-9..]*\).*Tbits.*/\1/p")
 	printf "TARGET uncoded BER: %f coded BER: %f\n" $uber_target $cber_target
 	python -c "import sys; sys.exit(1) if $uber_target < 0.1 and abs($cber_ref-$cber_target) < 0.01 else sys.exit(0)"
 	if [[ $? -eq 1 ]]; then echo "OK"; 

--- a/stm32/unittest/scripts/tst_api_demod_check
+++ b/stm32/unittest/scripts/tst_api_demod_check
@@ -118,81 +118,81 @@ case "${TEST_OPT}" in
 	;;
 
     700E_plain_test)
-    echo "Check reference decode"
-    p1=$(grep '^BER\.*: 0.000' ref_gen.log | wc -l)
-    p2=$(grep '^Coded BER: 0.000' ref_gen.log | wc -l)
-    if [[ $p1 -eq 1 && $p2 -eq 1 ]]; then echo "OK"; 
-    else echo "BAD"; 
+	echo "Check reference decode"
+	p1=$(grep '^BER\.*: 0.000' ref_gen.log | wc -l)
+	p2=$(grep '^Coded BER: 0.000' ref_gen.log | wc -l)
+	if [[ $p1 -eq 1 && $p2 -eq 1 ]]; then echo "OK"; 
+	else echo "BAD"; 
      	    let Fails=($Fails + 1)
      	fi
-    #
-    echo "Check target decode"
-    p1=$(grep '^BER\.*: 0.000' stderr.log | wc -l)
-    p2=$(grep '^Coded BER: 0.000' stderr.log | wc -l)
-    if [[ $p1 -eq 1 && $p2 -eq 1 ]]; then echo "OK"; 
-    else echo "BAD"; 
+	#
+	echo "Check target decode"
+	p1=$(grep '^BER\.*: 0.000' stderr.log | wc -l)
+	p2=$(grep '^Coded BER: 0.000' stderr.log | wc -l)
+	if [[ $p1 -eq 1 && $p2 -eq 1 ]]; then echo "OK"; 
+	else echo "BAD"; 
      	    let Fails=($Fails + 1)
      	fi
-    ;;
+	;;
 
     700E_AWGN_test)
-    echo "Check reference decode"
-    uber_ref=$(cat ref_gen.log | sed -n "s/^BER.* \([0-9..]*\) Tbits.*/\1/p")
-    cber_ref=$(cat ref_gen.log | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
-    printf "REF   uncoded BER: %f coded BER: %f\n" $uber_ref $cber_ref
+	echo "Check reference decode"
+	uber_ref=$(cat ref_gen.log | sed -n "s/^BER.* \([0-9..]*\) Tbits.*/\1/p")
+	cber_ref=$(cat ref_gen.log | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
+	printf "REF   uncoded BER: %f coded BER: %f\n" $uber_ref $cber_ref
 
-    # As per notes in tst_api_demod_setup, coded BER is unreliable
-    # for such a short test, so we'll just sanity check the
-    # reference uncoded BER here. Bash can't compare floats
-    # .... so use return code of some python script
-    python -c "import sys; sys.exit(1) if $uber_ref<0.1 else sys.exit(0)"
-    if [[ $? -eq 1 ]]; then echo "OK"; 
-    else echo "BAD"; 
+	# As per notes in tst_api_demod_setup, coded BER is unreliable
+	# for such a short test, so we'll just sanity check the
+	# reference uncoded BER here. Bash can't compare floats
+	# .... so use return code of some python script
+	python -c "import sys; sys.exit(1) if $uber_ref<0.1 else sys.exit(0)"
+	if [[ $? -eq 1 ]]; then echo "OK"; 
+	else echo "BAD"; 
      	    let Fails=($Fails + 1)
      	fi
 
-    echo "Check target decode"
-    uber_target=$(cat ref_gen.log | sed -n "s/^BER.* \([0-9..]*\) Tbits.*/\1/p")
-    cber_target=$(cat ref_gen.log | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
-    printf "TARGET uncoded BER: %f coded BER: %f\n" $uber_target $cber_target
-    python -c "import sys; sys.exit(1) if $uber_target<0.1 and abs($cber_ref-$cber_target)<0.01 else sys.exit(0)"
-    if [[ $? -eq 1 ]]; then echo "OK"; 
-    else echo "BAD"; 
+	echo "Check target decode"
+	uber_target=$(cat ref_gen.log | sed -n "s/^BER.* \([0-9..]*\) Tbits.*/\1/p")
+	cber_target=$(cat ref_gen.log | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
+	printf "TARGET uncoded BER: %f coded BER: %f\n" $uber_target $cber_target
+	python -c "import sys; sys.exit(1) if $uber_target<0.1 and abs($cber_ref-$cber_target)<0.01 else sys.exit(0)"
+	if [[ $? -eq 1 ]]; then echo "OK"; 
+	else echo "BAD"; 
      	    let Fails=($Fails + 1)
      	fi
-    ;;
+	;;
 
     700E_AWGN_codec)
-    # 1/ The two output files sound OK, and when plotted look very
-    #    similar, but they don't match on a sample-sample basis.
+	# 1/ The two output files sound OK, and when plotted look very
+	#    similar, but they don't match on a sample-sample basis.
+	
+	# 2/ Suspect some small state difference, or perhaps random
+	#    number generator diverging, sampling codec2_rand() at the
+	#    end of the x86 and stm32 test programs might show up any
+	#    differences.
 
-    # 2/ Suspect some small state difference, or perhaps random
-    #    number generator diverging, sampling codec2_rand() at the
-    #    end of the x86 and stm32 test programs might show up any
-    #    differences.
+	# 3/ At this stage - we can't make sample by sample automatic
+	#    tests work.  However there is value in running the test
+	#    to ensure no asserts are hit and the code doesn't crash
+	#    (e.g. due to an out of memory issues). A simple energy
+	#    comparison is used on the output speech files, which
+	#    will trap any large errors.
 
-    # 3/ At this stage - we can't make sample by sample automatic
-    #    tests work.  However there is value in running the test
-    #    to ensure no asserts are hit and the code doesn't crash
-    #    (e.g. due to an out of memory issues). A simple energy
-    #    comparison is used on the output speech files, which
-    #    will trap any large errors.
+	# 4/ We can also manually evaulate the ouput decoded speech by
+	#    listening to the output speech files.
 
-    # 4/ We can also manually evaulate the ouput decoded speech by
-    #    listening to the output speech files.
+	compare_energy;
 
-    compare_energy;
-
-    # make sure execution time stays within bounds
-    execution_time=mktmp
-    cat stdout.log | sed  -n "s/.*freedv_rx \([0-9..]*\) msecs/\1/p" > $execution_time
-    python -c "import sys; import numpy as np;  x=np.loadtxt(\"$execution_time\"); print(\"execution time max:: %5.2f mean: %5.2f ms\" % (np.max(x), np.mean(x))); sys.exit(1) if np.max(x) < 80.0 else sys.exit(0)"
-    if [[ $? -eq 1 ]]; then echo "execution time OK"; 
+	# make sure execution time stays within bounds
+	execution_time=mktmp
+	cat stdout.log | sed  -n "s/.*freedv_rx \([0-9..]*\) msecs/\1/p" > $execution_time
+	python -c "import sys; import numpy as np;  x=np.loadtxt(\"$execution_time\"); print(\"execution time max:: %5.2f mean: %5.2f ms\" % (np.max(x), np.mean(x))); sys.exit(1) if np.max(x) < 80.0 else sys.exit(0)"
+	if [[ $? -eq 1 ]]; then echo "execution time OK"; 
         else echo "BAD"; 
      	   let Fails=($Fails + 1)
         fi
 
-    ;;
+	;;
 
     1600_plain_codec)
 	compare_energy;

--- a/stm32/unittest/scripts/tst_api_demod_setup
+++ b/stm32/unittest/scripts/tst_api_demod_setup
@@ -92,7 +92,7 @@ case "${TEST_OPT}" in
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=100 if=../../../../raw/hts1.raw of=spch_in.raw \
 		> setup.log 2>&1
-	freedv_tx 700E spch_in.raw stm_in.raw --testframes --txbpf 0 \
+	freedv_tx 700E spch_in.raw stm_in.raw --testframes --txbpf 1 \
 		>> setup.log 2>&1
 	#
         # Reference
@@ -107,7 +107,7 @@ case "${TEST_OPT}" in
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=96 if=../../../../raw/hts1.raw of=spch_in.raw \
 		> setup.log 2>&1
-	freedv_tx 700E spch_in.raw mod_bits.raw --testframes --txbpf 0 \
+	freedv_tx 700E spch_in.raw mod_bits.raw --testframes --txbpf 1 \
 		  >> setup.log 2>&1
 	cohpsk_ch mod_bits.raw stm_in.raw -20 --Fs 8000 -f -5  2>&1 | tee setup.log
 	
@@ -136,7 +136,7 @@ case "${TEST_OPT}" in
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=48 if=../../../../raw/hts1.raw of=spch_in.raw \
 		> setup.log 2>&1
-	freedv_tx 700E spch_in.raw mod_bits.raw --txbpf 0 \
+	freedv_tx 700E spch_in.raw mod_bits.raw --txbpf 1 \
 		>> setup.log 2>&1
 	#
         # Reference - give it a hard time with some noise to exercise the LDPC codec and get us to max CPU
@@ -159,7 +159,7 @@ case "${TEST_OPT}" in
 	;;
     
     *)
-	printf "ERROR: invalid test option. Valid options are:\n  700D_plain_test\n  700D_AWGN_test\n  700D_AWGN_codec\n  1600_plain_codec\n"
+	printf "ERROR: invalid test option. Valid options are:\n  700[DE]_plain_test\n  700[DE]_AWGN_test\n  700[DE]_AWGN_codec\n  1600_plain_codec\n"
 	exit 1
       	;;
 

--- a/stm32/unittest/scripts/tst_api_demod_setup
+++ b/stm32/unittest/scripts/tst_api_demod_setup
@@ -109,22 +109,7 @@ case "${TEST_OPT}" in
 		> setup.log 2>&1
 	freedv_tx 700E spch_in.raw mod_bits.raw --testframes --txbpf 1 \
 		  >> setup.log 2>&1
-	cohpsk_ch mod_bits.raw stm_in.raw -20 --Fs 8000 -f -5  2>&1 | tee setup.log
-	
-        # Reference: - When the OFDM modem initially syncs, it often
-	#              has residual freq offset that causes abnormally
-	#              high LDPC decoder bit errors forthe first few
-	#              seconds.  This leads to a high coded BER being
-	#              reported for short duration tests.  This
-	#              settles down after a few seconds, and we get
-	#              the expected coded BER when averaging over
-	#              longer periods (e.g. 60s). However this
-	#              particular test is necessarily short due to the
-	#              slow speed of the semihosting system.  It is
-	#              therefore sufficient to check that the
-	#              performance is similar to the x86 C verison,
-	#              rather than expecting a low coded BER for a
-	#              short run.
+	cohpsk_ch mod_bits.raw stm_in.raw -22 --Fs 8000 -f -5  2>&1 | tee setup.log
 	
         freedv_rx 700E stm_in.raw ref_demod.raw -v --testframes  2>&1 --discard | tee ref_gen.log
 	;;

--- a/stm32/unittest/scripts/tst_api_demod_setup
+++ b/stm32/unittest/scripts/tst_api_demod_setup
@@ -92,7 +92,7 @@ case "${TEST_OPT}" in
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=100 if=../../../../raw/hts1.raw of=spch_in.raw \
     	> setup.log 2>&1
-    freedv_tx 700E spch_in.raw stm_in.raw --testframes --txbpf 0 \
+    freedv_tx 700E spch_in.raw stm_in.raw --testframes --txbpf 1 \
     	>> setup.log 2>&1
 
         # Reference

--- a/stm32/unittest/scripts/tst_api_demod_setup
+++ b/stm32/unittest/scripts/tst_api_demod_setup
@@ -88,62 +88,62 @@ case "${TEST_OPT}" in
     700E_plain_test )
     	# Config is <mode>, <teswtframes> 
     	echo "81000010" > stm_cfg.txt
-
+	#
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=100 if=../../../../raw/hts1.raw of=spch_in.raw \
-    	> setup.log 2>&1
-    freedv_tx 700E spch_in.raw stm_in.raw --testframes --txbpf 1 \
-    	>> setup.log 2>&1
-
+		> setup.log 2>&1
+	freedv_tx 700E spch_in.raw stm_in.raw --testframes --txbpf 0 \
+		>> setup.log 2>&1
+	#
         # Reference
         freedv_rx 700E stm_in.raw ref_demod.raw -v --testframes \
-    	> ref_gen.log 2>&1
-    ;;
+		> ref_gen.log 2>&1
+	;;
 
     700E_AWGN_test )
     	# Config is <mode>, <teswtframes> 
     	echo "81000010" > stm_cfg.txt
-
+	#
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=96 if=../../../../raw/hts1.raw of=spch_in.raw \
-    	    > setup.log 2>&1
-        freedv_tx 700E spch_in.raw mod_bits.raw --testframes --txbpf 1 \
-        	  >> setup.log 2>&1
-        cohpsk_ch mod_bits.raw stm_in.raw -20 --Fs 8000 -f -5  2>&1 | tee setup.log
-
+		> setup.log 2>&1
+	freedv_tx 700E spch_in.raw mod_bits.raw --testframes --txbpf 0 \
+		  >> setup.log 2>&1
+	cohpsk_ch mod_bits.raw stm_in.raw -20 --Fs 8000 -f -5  2>&1 | tee setup.log
+	
         # Reference: - When the OFDM modem initially syncs, it often
-        #              has residual freq offset that causes abnormally
-        #              high LDPC decoder bit errors forthe first few
-        #              seconds.  This leads to a high coded BER being
-        #              reported for short duration tests.  This
-        #              settles down after a few seconds, and we get
-        #              the expected coded BER when averaging over
-        #              longer periods (e.g. 60s). However this
-        #              particular test is necessarily short due to the
-        #              slow speed of the semihosting system.  It is
-        #              therefore sufficient to check that the
-        #              performance is similar to the x86 C verison,
-        #              rather than expecting a low coded BER for a
-        #              short run.
-
+	#              has residual freq offset that causes abnormally
+	#              high LDPC decoder bit errors forthe first few
+	#              seconds.  This leads to a high coded BER being
+	#              reported for short duration tests.  This
+	#              settles down after a few seconds, and we get
+	#              the expected coded BER when averaging over
+	#              longer periods (e.g. 60s). However this
+	#              particular test is necessarily short due to the
+	#              slow speed of the semihosting system.  It is
+	#              therefore sufficient to check that the
+	#              performance is similar to the x86 C verison,
+	#              rather than expecting a low coded BER for a
+	#              short run.
+	
         freedv_rx 700E stm_in.raw ref_demod.raw -v --testframes  2>&1 --discard | tee ref_gen.log
-    ;;
+	;;
 
     700E_AWGN_codec )
     	# Config is <mode>, <teswtframes> 
     	echo "80000020" > stm_cfg.txt
-
+	#
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=48 if=../../../../raw/hts1.raw of=spch_in.raw \
-    	    > setup.log 2>&1
-        freedv_tx 700E spch_in.raw mod_bits.raw --txbpf 1 \
-        	>> setup.log 2>&1
-
+		> setup.log 2>&1
+	freedv_tx 700E spch_in.raw mod_bits.raw --txbpf 0 \
+		>> setup.log 2>&1
+	#
         # Reference - give it a hard time with some noise to exercise the LDPC codec and get us to max CPU
-        cohpsk_ch mod_bits.raw stm_in.raw -20 --Fs 8000 -f -5  2>&1 | tee setup.log
-            freedv_rx 700E stm_in.raw ref_demod.raw -v \
-        	> ref_gen.log 2>&1
-    ;;
+	cohpsk_ch mod_bits.raw stm_in.raw -20 --Fs 8000 -f -5  2>&1 | tee setup.log
+        freedv_rx 700E stm_in.raw ref_demod.raw -v \
+		> ref_gen.log 2>&1
+	;;
 
     1600_plain_codec )
     	# Config is <mode>, <teswtframes> 

--- a/stm32/unittest/scripts/tst_api_demod_setup
+++ b/stm32/unittest/scripts/tst_api_demod_setup
@@ -85,6 +85,66 @@ case "${TEST_OPT}" in
 		> ref_gen.log 2>&1
 	;;
 
+    700E_plain_test )
+    	# Config is <mode>, <teswtframes> 
+    	echo "81000010" > stm_cfg.txt
+
+        # Copy N frames of a raw audio file to stm_in.raw. 
+        dd bs=1280 count=100 if=../../../../raw/hts1.raw of=spch_in.raw \
+    	> setup.log 2>&1
+    freedv_tx 700E spch_in.raw stm_in.raw --testframes --txbpf 0 \
+    	>> setup.log 2>&1
+
+        # Reference
+        freedv_rx 700E stm_in.raw ref_demod.raw -v --testframes \
+    	> ref_gen.log 2>&1
+    ;;
+
+    700E_AWGN_test )
+    	# Config is <mode>, <teswtframes> 
+    	echo "81000010" > stm_cfg.txt
+
+        # Copy N frames of a raw audio file to stm_in.raw. 
+        dd bs=1280 count=96 if=../../../../raw/hts1.raw of=spch_in.raw \
+    	    > setup.log 2>&1
+        freedv_tx 700E spch_in.raw mod_bits.raw --testframes --txbpf 1 \
+        	  >> setup.log 2>&1
+        cohpsk_ch mod_bits.raw stm_in.raw -20 --Fs 8000 -f -5  2>&1 | tee setup.log
+
+        # Reference: - When the OFDM modem initially syncs, it often
+        #              has residual freq offset that causes abnormally
+        #              high LDPC decoder bit errors forthe first few
+        #              seconds.  This leads to a high coded BER being
+        #              reported for short duration tests.  This
+        #              settles down after a few seconds, and we get
+        #              the expected coded BER when averaging over
+        #              longer periods (e.g. 60s). However this
+        #              particular test is necessarily short due to the
+        #              slow speed of the semihosting system.  It is
+        #              therefore sufficient to check that the
+        #              performance is similar to the x86 C verison,
+        #              rather than expecting a low coded BER for a
+        #              short run.
+
+        freedv_rx 700E stm_in.raw ref_demod.raw -v --testframes  2>&1 --discard | tee ref_gen.log
+    ;;
+
+    700E_AWGN_codec )
+    	# Config is <mode>, <teswtframes> 
+    	echo "80000020" > stm_cfg.txt
+
+        # Copy N frames of a raw audio file to stm_in.raw. 
+        dd bs=1280 count=48 if=../../../../raw/hts1.raw of=spch_in.raw \
+    	    > setup.log 2>&1
+        freedv_tx 700E spch_in.raw mod_bits.raw --txbpf 1 \
+        	>> setup.log 2>&1
+
+        # Reference - give it a hard time with some noise to exercise the LDPC codec and get us to max CPU
+        cohpsk_ch mod_bits.raw stm_in.raw -20 --Fs 8000 -f -5  2>&1 | tee setup.log
+            freedv_rx 700E stm_in.raw ref_demod.raw -v \
+        	> ref_gen.log 2>&1
+    ;;
+
     1600_plain_codec )
     	# Config is <mode>, <teswtframes> 
     	echo "00000010" > stm_cfg.txt

--- a/stm32/unittest/scripts/tst_api_mod_check
+++ b/stm32/unittest/scripts/tst_api_mod_check
@@ -65,6 +65,44 @@ case "${TEST_OPT}" in
         fi
 	;;
 
+    700E_TEST)
+        #
+        echo -e "\nReference check"
+        if freedv_rx 700E ref_mod.raw ref_rx.raw --testframes; then
+            echo "Passed"
+        else
+            echo "Failed"
+            let Fails=($Fails + 1)
+        fi
+        #
+        echo -e "\nTarget check"
+        if freedv_rx 700E stm_out.raw stm_rx.raw --testframes; then
+            echo "Passed"
+        else
+            echo "Failed"
+            let Fails=($Fails + 1)
+        fi
+        #
+        echo -e "\nCompare output binary data"
+        if compare_ints -s -b2 -t4 ref_mod.raw stm_out.raw; then 
+            echo "Passed"
+        else
+            echo "Failed"
+            let Fails=($Fails + 1)
+        fi
+	;;
+
+    700E_CODEC)
+        #
+        echo -e "\nCompare output binary data"
+        if compare_ints -s -b2 -t4 ref_mod.raw stm_out.raw; then 
+            echo "Passed"
+        else
+            echo "Failed"
+            let Fails=($Fails + 1)
+        fi
+	;;
+
     esac
 
 if (( $Fails == 0 )); then

--- a/stm32/unittest/scripts/tst_api_mod_setup
+++ b/stm32/unittest/scripts/tst_api_mod_setup
@@ -53,7 +53,7 @@ case "${TEST_OPT}" in
 
     700E_TEST )
     	# Config is <mode>, <teswtframes>, <clip>, <bpf>
-    	echo "81110000" > stm_cfg.txt
+    	echo "81010000" > stm_cfg.txt
 	#
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=48 if=../../../../raw/hts1.raw of=stm_in.raw \
@@ -66,7 +66,7 @@ case "${TEST_OPT}" in
 
     700E_CODEC )
     	# Config is <mode>, <teswtframes>, <cip>, <bpf>
-    	echo "80110000" > stm_cfg.txt
+    	echo "80010000" > stm_cfg.txt
 	#
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=48 if=../../../../raw/hts1.raw of=stm_in.raw \

--- a/stm32/unittest/scripts/tst_api_mod_setup
+++ b/stm32/unittest/scripts/tst_api_mod_setup
@@ -53,7 +53,7 @@ case "${TEST_OPT}" in
 
     700E_TEST )
     	# Config is <mode>, <teswtframes> 
-    	echo "71000000" > stm_cfg.txt
+    	echo "81000000" > stm_cfg.txt
 	#
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=48 if=../../../../raw/hts1.raw of=stm_in.raw \
@@ -66,7 +66,7 @@ case "${TEST_OPT}" in
 
     700E_CODEC )
     	# Config is <mode>, <teswtframes> 
-    	echo "70000000" > stm_cfg.txt
+    	echo "80000000" > stm_cfg.txt
 	#
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=48 if=../../../../raw/hts1.raw of=stm_in.raw \

--- a/stm32/unittest/scripts/tst_api_mod_setup
+++ b/stm32/unittest/scripts/tst_api_mod_setup
@@ -26,7 +26,7 @@ cd "${RUN_DIR}"
 case "${TEST_OPT}" in
 
     700D_TEST )
-    	# Config is <mode>, <teswtframes> 
+    	# Config is <mode>, <teswtframes>, <clip>, <bpf>
     	echo "71000000" > stm_cfg.txt
 	#
         # Copy N frames of a raw audio file to stm_in.raw. 
@@ -39,7 +39,7 @@ case "${TEST_OPT}" in
 	;;
 
     700D_CODEC )
-    	# Config is <mode>, <teswtframes> 
+    	# Config is <mode>, <teswtframes>, <clip>, <bpf>
     	echo "70000000" > stm_cfg.txt
 	#
         # Copy N frames of a raw audio file to stm_in.raw. 
@@ -52,8 +52,8 @@ case "${TEST_OPT}" in
 	;;
 
     700E_TEST )
-    	# Config is <mode>, <teswtframes> 
-    	echo "81000000" > stm_cfg.txt
+    	# Config is <mode>, <teswtframes>, <clip>, <bpf>
+    	echo "81110000" > stm_cfg.txt
 	#
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=48 if=../../../../raw/hts1.raw of=stm_in.raw \
@@ -65,8 +65,8 @@ case "${TEST_OPT}" in
 	;;
 
     700E_CODEC )
-    	# Config is <mode>, <teswtframes> 
-    	echo "80000000" > stm_cfg.txt
+    	# Config is <mode>, <teswtframes>, <cip>, <bpf>
+    	echo "80110000" > stm_cfg.txt
 	#
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=48 if=../../../../raw/hts1.raw of=stm_in.raw \

--- a/stm32/unittest/scripts/tst_api_mod_setup
+++ b/stm32/unittest/scripts/tst_api_mod_setup
@@ -53,27 +53,27 @@ case "${TEST_OPT}" in
 
     700E_TEST )
     	# Config is <mode>, <teswtframes>, <clip>, <bpf>
-    	echo "81010000" > stm_cfg.txt
+    	echo "81110000" > stm_cfg.txt
 	#
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=48 if=../../../../raw/hts1.raw of=stm_in.raw \
 		> setup.log 2>&1
 	#
         # Reference
-        freedv_tx 700E stm_in.raw ref_mod.raw --testframes --txbpf 1 \
+        freedv_tx 700E stm_in.raw ref_mod.raw --testframes --txbpf 1 --clip 1 \
 		> ref_gen.log 2>&1
 	;;
 
     700E_CODEC )
     	# Config is <mode>, <teswtframes>, <cip>, <bpf>
-    	echo "80010000" > stm_cfg.txt
+    	echo "80110000" > stm_cfg.txt
 	#
         # Copy N frames of a raw audio file to stm_in.raw. 
         dd bs=1280 count=48 if=../../../../raw/hts1.raw of=stm_in.raw \
 		> setup.log 2>&1
 	#
         # Reference
-        freedv_tx 700E stm_in.raw ref_mod.raw --txbpf 1 \
+        freedv_tx 700E stm_in.raw ref_mod.raw --txbpf 1 --clip 1 \
 		> ref_gen.log 2>&1
 	;;
 

--- a/stm32/unittest/scripts/tst_api_mod_setup
+++ b/stm32/unittest/scripts/tst_api_mod_setup
@@ -51,8 +51,34 @@ case "${TEST_OPT}" in
 		> ref_gen.log 2>&1
 	;;
 
+    700E_TEST )
+    	# Config is <mode>, <teswtframes> 
+    	echo "71000000" > stm_cfg.txt
+	#
+        # Copy N frames of a raw audio file to stm_in.raw. 
+        dd bs=1280 count=48 if=../../../../raw/hts1.raw of=stm_in.raw \
+		> setup.log 2>&1
+	#
+        # Reference
+        freedv_tx 700E stm_in.raw ref_mod.raw --testframes --txbpf 1 \
+		> ref_gen.log 2>&1
+	;;
+
+    700E_CODEC )
+    	# Config is <mode>, <teswtframes> 
+    	echo "70000000" > stm_cfg.txt
+	#
+        # Copy N frames of a raw audio file to stm_in.raw. 
+        dd bs=1280 count=48 if=../../../../raw/hts1.raw of=stm_in.raw \
+		> setup.log 2>&1
+	#
+        # Reference
+        freedv_tx 700E stm_in.raw ref_mod.raw --txbpf 1 \
+		> ref_gen.log 2>&1
+	;;
+
     *)
-	printf "ERROR: invalid test option. Valid options are:\n  700D_TEST\n  700D_CODEC\n"
+	printf "ERROR: invalid test option. Valid options are:\n  700D_TEST\n  700D_CODEC\n  700E_TEST\n  700E_CODEC\n"
 	exit 1
       	;;
     esac

--- a/stm32/unittest/src/CMakeLists.txt
+++ b/stm32/unittest/src/CMakeLists.txt
@@ -123,6 +123,14 @@ add_test(NAME tst_api_mod_700D_CODEC
          COMMAND sh -c "./run_stm32_tst tst_api_mod 700D_CODEC ${UT_PARAMS}"
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)
 
+add_test(NAME tst_api_mod_700E_TEST
+         COMMAND sh -c "./run_stm32_tst tst_api_mod 700E_TEST ${UT_PARAMS}"
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)
+
+add_test(NAME tst_api_mod_700E_CODEC
+         COMMAND sh -c "./run_stm32_tst tst_api_mod 700E_CODEC ${UT_PARAMS}"
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)
+
 add_test(NAME tst_api_demod_700D_plain_test
          COMMAND sh -c "./run_stm32_tst tst_api_demod 700D_plain_test ${UT_PARAMS}"
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)

--- a/stm32/unittest/src/CMakeLists.txt
+++ b/stm32/unittest/src/CMakeLists.txt
@@ -144,15 +144,17 @@ add_test(NAME tst_api_demod_700D_AWGN_codec
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)
 
 add_test(NAME tst_api_demod_700E_plain_test
-         COMMAND sh -c "./run_stm32_tst tst_api_demod 700D_plain_test ${UT_PARAMS}"
+         COMMAND sh -c "./run_stm32_tst tst_api_demod 700E_plain_test ${UT_PARAMS}"
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)
-                                                                                                                                                                                            add_test(NAME tst_api_demod_700E_AWGN_test
-         COMMAND sh -c "./run_stm32_tst tst_api_demod 700D_AWGN_test ${UT_PARAMS}"
+
+add_test(NAME tst_api_demod_700E_AWGN_test
+         COMMAND sh -c "./run_stm32_tst tst_api_demod 700E_AWGN_test ${UT_PARAMS}"
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)
-                                                                                                                                                                                            add_test(NAME tst_api_demod_700E_AWGN_codec
-        COMMAND sh -c "./run_stm32_tst tst_api_demod 700D_AWGN_codec ${UT_PARAMS}"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)
-                                                                                                
+
+add_test(NAME tst_api_demod_700E_AWGN_codec
+         COMMAND sh -c "./run_stm32_tst tst_api_demod 700E_AWGN_codec ${UT_PARAMS}"
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)
+
 add_test(NAME tst_api_demod_1600_plain_codec
          COMMAND sh -c "./run_stm32_tst tst_api_demod 1600_plain_codec ${UT_PARAMS}"
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)

--- a/stm32/unittest/src/CMakeLists.txt
+++ b/stm32/unittest/src/CMakeLists.txt
@@ -143,6 +143,16 @@ add_test(NAME tst_api_demod_700D_AWGN_codec
          COMMAND sh -c "./run_stm32_tst tst_api_demod 700D_AWGN_codec ${UT_PARAMS}"
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)
 
+add_test(NAME tst_api_demod_700E_plain_test
+         COMMAND sh -c "./run_stm32_tst tst_api_demod 700D_plain_test ${UT_PARAMS}"
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)
+                                                                                                                                                                                            add_test(NAME tst_api_demod_700E_AWGN_test
+         COMMAND sh -c "./run_stm32_tst tst_api_demod 700D_AWGN_test ${UT_PARAMS}"
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)
+                                                                                                                                                                                            add_test(NAME tst_api_demod_700E_AWGN_codec
+        COMMAND sh -c "./run_stm32_tst tst_api_demod 700D_AWGN_codec ${UT_PARAMS}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)
+                                                                                                
 add_test(NAME tst_api_demod_1600_plain_codec
          COMMAND sh -c "./run_stm32_tst tst_api_demod 1600_plain_codec ${UT_PARAMS}"
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../scripts)

--- a/stm32/unittest/src/tst_api_demod.c
+++ b/stm32/unittest/src/tst_api_demod.c
@@ -132,6 +132,11 @@ int main(int argc, char *argv[]) {
         exit(1);
     }
     config_mode = config[0] - '0';
+    if (config_mode == 8)
+    {
+        // For the purposes of the UT system, '8' is 700E.
+        config_mode = FREEDV_MODE_700E;
+    }
     config_testframes = config[1] - '0';
     config_verbose = config[6] - '0';
     //config_profile = config[7] - '0';

--- a/stm32/unittest/src/tst_api_demod.c
+++ b/stm32/unittest/src/tst_api_demod.c
@@ -215,7 +215,7 @@ int main(int argc, char *argv[]) {
         int Terrs = freedv_get_total_bit_errors(freedv);
         fprintf(stderr, "BER......: %5.4f Tbits: %5d Terrs: %5d\n",
 	    (double)Terrs/Tbits, Tbits, Terrs);
-        if (config_mode == FREEDV_MODE_700D) {
+        if (config_mode == FREEDV_MODE_700D || config_mode == FREEDV_MODE_700E) {
             int Tbits_coded = freedv_get_total_bits_coded(freedv);
             int Terrs_coded = freedv_get_total_bit_errors_coded(freedv);
             fprintf(stderr, "Coded BER: %5.4f Tbits: %5d Terrs: %5d\n",

--- a/stm32/unittest/src/tst_api_mod.c
+++ b/stm32/unittest/src/tst_api_mod.c
@@ -132,6 +132,8 @@ int main(int argc, char *argv[]) {
     // Test configuration, read from stm_cfg.txt
     int     config_mode;        // 0
     int     config_testframes;  // 1
+    int     use_clip = 0;       // 2
+    int     use_txbpf = 0;      // 3
     //int     config_verbose;   // 6
     //int     config_profile;   // 7
     char config[8];
@@ -151,6 +153,8 @@ int main(int argc, char *argv[]) {
         config_mode = FREEDV_MODE_700E;
     }
     config_testframes = config[1] - '0';
+    use_clip = config[2] - '0';
+    use_txbpf = config[3] - '0';
     //config_verbose = config[6] - '0';
     //config_profile = config[7] - '0';
     close(f_cfg);
@@ -158,8 +162,6 @@ int main(int argc, char *argv[]) {
     //int use_codectx = 0; 
     //int use_datatx = 0; 
     //int use_testframes = 0; 
-    int use_clip = 0; 
-    int use_txbpf = 0;
     int use_ext_vco = 0;
 
     ////////

--- a/stm32/unittest/src/tst_api_mod.c
+++ b/stm32/unittest/src/tst_api_mod.c
@@ -145,6 +145,11 @@ int main(int argc, char *argv[]) {
         exit(1);
     }
     config_mode = config[0] - '0';
+    if (config_mode == 8)
+    {
+        // For the purposes of the UT system, '8' is 700E.
+        config_mode = FREEDV_MODE_700E;
+    }
     config_testframes = config[1] - '0';
     //config_verbose = config[6] - '0';
     //config_profile = config[7] - '0';


### PR DESCRIPTION
Adds 700E support to the SM1000. Based on the dr-stm32-update branch due to requiring its fixes to actually run the firmware.

@drowe67, I noticed that the 700E signal seemed noisier on my other radio's waterfall than 1600 and 700D. Not sure why that's the case since I thought they were all supposed to be around the same output level?

CPU Load measurements (PE3):

| Mode | State | Period | On time | CPU Load est | Comment |
| --- | --- | --- | --- | --- | --- |
| 700D | Rx | 159.5 ms | 84.0 ms | 53% | Acquisition is probably worst case | 
| 700D | Tx | 158.0 ms | 98.5 ms | 62% | 
| 700D | Tx BPF + Clip | 161.0 ms | 128.5 ms | 80% | 
| 700E | Rx | 80.0 ms | 44.0 ms | 55% | 
| 700E | Tx | 80.0 ms | 50.0 ms | 63% | 
| 700E | Tx BPF + Clip | 80.1 ms | 65.0 ms | 81% | 
