### PR TITLE
moved rx_sym callback to freedv_api_internal.h

### DIFF
--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -145,7 +145,6 @@ struct freedv_advanced {
 
 // Called when text message char is decoded
 typedef void (*freedv_callback_rx)(void *, char);
-typedef void (*freedv_callback_rx_sym)(void *, _Complex float, float);
 // Called when new text message char is needed
 typedef char (*freedv_callback_tx)(void *);
 typedef void (*freedv_calback_error_pattern)
@@ -212,7 +211,6 @@ int freedv_check_crc16_unpacked(unsigned char *unpacked_bits, int nbits);
 // Set parameters ------------------------------------------------------------
 
 void freedv_set_callback_txt            (struct freedv *freedv, freedv_callback_rx rx, freedv_callback_tx tx, void *callback_state);
-void freedv_set_callback_txt_sym        (struct freedv *freedv, freedv_callback_rx_sym rx, void *callback_state);
 void freedv_set_callback_protocol       (struct freedv *freedv, freedv_callback_protorx rx, freedv_callback_prototx tx, void *callback_state);
 void freedv_set_callback_data           (struct freedv *freedv, freedv_callback_datarx datarx, freedv_callback_datatx datatx, void *callback_state);
 void freedv_set_test_frames		        (struct freedv *freedv, int test_frames);

--- a/src/freedv_api_internal.h
+++ b/src/freedv_api_internal.h
@@ -230,6 +230,10 @@ int freedv_rx_fsk_ldpc_data(struct freedv *f, COMP demod_in[]);
 
 int freedv_bits_to_speech(struct freedv *f, short speech_out[], short demod_in[], int rx_status);
 
+// for the reliable text protocol we need to pass symbols back rather than text
+typedef void (*freedv_callback_rx_sym)(void *, _Complex float, float);
+void freedv_set_callback_txt_sym (struct freedv *freedv, freedv_callback_rx_sym rx, void *callback_state);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Attempt to remove the need for `_Complex` support in `freedv_api.h`, and hopefully remove the need for #232 and #233

We probably don't need this API function and it's typedef exposed to general API users, as it's pretty much a custom hook for the reliable text system.

@tmiw is this a reasonable fix?  I couldn't see this being used anywhere else but internally in `libcodec2`.  Sorry if I've missed something ...