### PR TITLE
Make `rx_filter_coh()` static

### DIFF
--- a/src/cohpsk.c
+++ b/src/cohpsk.c
@@ -809,7 +809,7 @@ typedef float float4 __attribute__ ((vector_size (16)));
 
 \*---------------------------------------------------------------------------*/
 
-inline void rx_filter_coh(COMP rx_filt[COHPSK_NC+1][P+1], int Nc, COMP rx_baseband[COHPSK_NC+1][COHPSK_M+COHPSK_M/P], COMP rx_filter_memory[COHPSK_NC+1][+COHPSK_NFILTER], int nin)
+static inline void rx_filter_coh(COMP rx_filt[COHPSK_NC+1][P+1], int Nc, COMP rx_baseband[COHPSK_NC+1][COHPSK_M+COHPSK_M/P], COMP rx_filter_memory[COHPSK_NC+1][+COHPSK_NFILTER], int nin)
 {
     int c,i,j,k,l;
     int n=COHPSK_M/P;


### PR DESCRIPTION
Downstream issue: https://bugs.gentoo.org/817437