### PR TITLE
Precalculate c for OFDM dft/idft.

### DIFF
--- a/src/ofdm_internal.h
+++ b/src/ofdm_internal.h
@@ -236,6 +236,14 @@ struct OFDM {
     
     char *codename;
     char *state_machine;
+
+#ifndef STM32F40_41xxx
+    // On non-SM1000 platforms, we precompute c for dft and idft to make it easier
+    // to use SIMD instructions to optimize those functions. This isn't done on SM1000
+    // due to memory constraints. Each is (ofdm->m * (ofdm->nc + 2)) in size.
+    complex float* tx_c;
+    complex float* rx_c;
+#endif // STM32F40_41xxx
 };
 
 /* Prototypes */


### PR DESCRIPTION
This PR is to review the dft/idft optimizations originally introduced in #242.

*gprof output:*

[freedv_tx_dft.txt](https://github.com/drowe67/codec2/files/7431151/freedv_tx_dft.txt) (no difference w/master)
[freedv_tx_master.txt](https://github.com/drowe67/codec2/files/7431154/freedv_tx_master.txt) (no difference w/master)
[freedv_rx_dft.txt](https://github.com/drowe67/codec2/files/7431153/freedv_rx_dft.txt) (6.49us/call)
[freedv_rx_master.txt](https://github.com/drowe67/codec2/files/7431152/freedv_rx_master.txt) (11.69us/call)

I used the following calls for test: 

```
./freedv_tx 700D ve9qrp.raw ve9qrp_processed.raw
./freedv_rx 700D ve9qrp_processed.raw /dev/null
```
