### PR TITLE
MSYS2/MinGW Compiler problem using alloca.h

### DIFF
--- a/src/fmfsk.c
+++ b/src/fmfsk.c
@@ -196,7 +196,7 @@ void fmfsk_demod(struct FMFSK *fmfsk, uint8_t rx_bits[],float fmfsk_in[]){
     memcpy (&oldsamps[nold], &fmfsk_in[0]        , sizeof(float)*nin );
     
     /* Allocate memory for filtering */
-    float *rx_filt = alloca(sizeof(float)*(nsym+1)*Ts);
+    float *rx_filt = malloc(sizeof(float)*(nsym+1)*Ts);
     
     /* Integrate over Ts input symbols at every offset */
     for(i=0; i<(nsym+1)*Ts; i++){
@@ -364,4 +364,6 @@ void fmfsk_demod(struct FMFSK *fmfsk, uint8_t rx_bits[],float fmfsk_in[]){
     
     modem_probe_samp_f("t_norm_rx_timing",&norm_rx_timing,1);
     modem_probe_samp_f("t_rx_filt",rx_filt,(nsym+1)*Ts);
+
+    free(rx_filt);
 }

--- a/src/fmfsk_demod.c
+++ b/src/fmfsk_demod.c
@@ -28,6 +28,7 @@
 */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "fmfsk.h"
 #include "modem_stats.h"
@@ -85,13 +86,13 @@ int main(int argc,char *argv[]){
     
     if(fin==NULL || fout==NULL || fmfsk==NULL){
         fprintf(stderr,"Couldn't open test vector files\n");
-        goto cleanup;
+        exit(1);
     }
     
     /* allocate buffers for processing */
-    bitbuf = (uint8_t*)alloca(sizeof(uint8_t)*fmfsk->nbit);
-    rawbuf = (int16_t*)alloca(sizeof(int16_t)*(fmfsk->N+fmfsk->Ts*2));
-    modbuf = (float*)alloca(sizeof(float)*(fmfsk->N+fmfsk->Ts*2));
+    bitbuf = (uint8_t*)malloc(sizeof(uint8_t)*fmfsk->nbit);
+    rawbuf = (int16_t*)malloc(sizeof(int16_t)*(fmfsk->N+fmfsk->Ts*2));
+    modbuf = (float*)malloc(sizeof(float)*(fmfsk->N+fmfsk->Ts*2));
     
     /* Demodulate! */
     while( fread(rawbuf,sizeof(int16_t),fmfsk_nin(fmfsk),fin) == fmfsk_nin(fmfsk) ){
@@ -135,10 +136,15 @@ int main(int argc,char *argv[]){
     }
     
     modem_probe_close();
-    cleanup:
+
+    free(modbuf);
+    free(rawbuf);
+    free(bitbuf);
+
     fclose(fin);
     fclose(fout);
     fmfsk_destroy(fmfsk);
+
     exit(0);
 }
 

--- a/src/fmfsk_mod.c
+++ b/src/fmfsk_mod.c
@@ -70,13 +70,13 @@ int main(int argc,char *argv[]){
     
     if(fin==NULL || fout==NULL || fmfsk==NULL){
         fprintf(stderr,"Couldn't open test vector files\n");
-        goto cleanup;
+        exit(1);
     }
     
     /* allocate buffers for processing */
-    bitbuf = (uint8_t*)alloca(sizeof(uint8_t)*fmfsk->nbit);
-    rawbuf = (int16_t*)alloca(sizeof(int16_t)*fmfsk->N);
-    modbuf = (float*)alloca(sizeof(float)*fmfsk->N);
+    bitbuf = (uint8_t*)malloc(sizeof(uint8_t)*fmfsk->nbit);
+    rawbuf = (int16_t*)malloc(sizeof(int16_t)*fmfsk->N);
+    modbuf = (float*)malloc(sizeof(float)*fmfsk->N);
     
     /* Modulate! */
     while( fread(bitbuf,sizeof(uint8_t),fmfsk->nbit,fin) == fmfsk->nbit ){
@@ -91,9 +91,14 @@ int main(int argc,char *argv[]){
 	}
     }
     
-    cleanup:
+    free(modbuf);
+    free(rawbuf);
+    free(bitbuf);
+
+    fmfsk_destroy(fmfsk);
+
     fclose(fin);
     fclose(fout);
-    fmfsk_destroy(fmfsk);
+
     exit(0);
 }

--- a/src/freedv_fsk.c
+++ b/src/freedv_fsk.c
@@ -145,8 +145,8 @@ void freedv_fsk_ldpc_open(struct freedv *f, struct freedv_advanced *adv) {
 
     f->bits_per_modem_frame = f->ldpc->data_bits_per_frame;
     int bits_per_frame = f->ldpc->coded_bits_per_frame + sizeof(fsk_ldpc_uw);
-    f->tx_payload_bits = malloc(f->bits_per_modem_frame); assert(f->tx_payload_bits != NULL);
-    f->rx_payload_bits = malloc(f->bits_per_modem_frame); assert(f->rx_payload_bits != NULL);
+    f->tx_payload_bits = MALLOC(f->bits_per_modem_frame); assert(f->tx_payload_bits != NULL);
+    f->rx_payload_bits = MALLOC(f->bits_per_modem_frame); assert(f->rx_payload_bits != NULL);
 
     /* sample buffer size for tx modem samples, we modulate a full frame */
     f->n_nom_modem_samples = f->fsk->Ts*(bits_per_frame/(f->fsk->mode>>1));
@@ -163,12 +163,12 @@ void freedv_fsk_ldpc_open(struct freedv *f, struct freedv_advanced *adv) {
 
     /* deframer set up */
     f->frame_llr_size = 2*bits_per_frame;
-    f->frame_llr = (float*)malloc(f->frame_llr_size*sizeof(float)); assert(f->frame_llr != NULL);
+    f->frame_llr = (float*)MALLOC(f->frame_llr_size*sizeof(float)); assert(f->frame_llr != NULL);
     f->frame_llr_nbits = 0;
 
-    f->twoframes_hard = malloc(2*bits_per_frame); assert(f->twoframes_hard != NULL);
+    f->twoframes_hard = MALLOC(2*bits_per_frame); assert(f->twoframes_hard != NULL);
     memset(f->twoframes_hard, 0, 2*bits_per_frame);
-    f->twoframes_llr = (float*)malloc(2*bits_per_frame*sizeof(float)); assert(f->twoframes_llr != NULL);
+    f->twoframes_llr = (float*)MALLOC(2*bits_per_frame*sizeof(float)); assert(f->twoframes_llr != NULL);
     for(int i=0; i<2*bits_per_frame; i++) f->twoframes_llr[i] = 0.0;
 
     /* currently configured a simple frame-frame approach */
@@ -227,7 +227,7 @@ void freedv_tx_fsk_voice(struct freedv *f, short mod_out[]) {
     }
 
     /* Allocate floating point buffer for FSK mod */
-    tx_float = alloca(sizeof(float)*f->n_nom_modem_samples);
+    tx_float = MALLOC(sizeof(float)*f->n_nom_modem_samples);
 
     /* do 4fsk mod */
     if(FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)){
@@ -252,6 +252,8 @@ void freedv_tx_fsk_voice(struct freedv *f, short mod_out[]) {
             mod_out[i] = (short)(tx_float[i]*FMFSK_SCALE);
         }
     }
+
+    FREE(tx_float);
 }
 
 /* TX routines for 2400 FSK modes, after codec2 encoding */
@@ -297,7 +299,7 @@ void freedv_comptx_fsk_voice(struct freedv *f, COMP mod_out[]) {
     }
 
     /* Allocate floating point buffer for FSK mod */
-    tx_float = alloca(sizeof(float)*f->n_nom_modem_samples);
+    tx_float = MALLOC(sizeof(float)*f->n_nom_modem_samples);
 
     /* do 4fsk mod */
     if(FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)){
@@ -314,6 +316,8 @@ void freedv_comptx_fsk_voice(struct freedv *f, COMP mod_out[]) {
             mod_out[i].real = (tx_float[i]);
         }
     }
+
+    FREE(tx_float);
 }
 
 /* TX routines for 2400 FSK modes, data channel */
@@ -327,7 +331,7 @@ void freedv_tx_fsk_data(struct freedv *f, short mod_out[]) {
     	fvhff_frame_data_bits(f->deframer, FREEDV_VHF_FRAME_A,(uint8_t*)(f->tx_bits));
 
     /* Allocate floating point buffer for FSK mod */
-    tx_float = alloca(sizeof(float)*f->n_nom_modem_samples);
+    tx_float = MALLOC(sizeof(float)*f->n_nom_modem_samples);
 
     /* do 4fsk mod */
     if (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)){
@@ -344,6 +348,8 @@ void freedv_tx_fsk_data(struct freedv *f, short mod_out[]) {
             mod_out[i] = (short)(tx_float[i]*FMFSK_SCALE);
         }
     }
+
+    FREE(tx_float);
 }
 
 int freedv_tx_fsk_ldpc_bits_per_frame(struct freedv *f) {

--- a/src/fsk.c
+++ b/src/fsk.c
@@ -35,10 +35,6 @@
 /* This needs square roots, may take more cpu time than it's worth */
 #define EST_EBNO
 
-/* This is a flag to make the mod/demod allocate their memory on the stack instead of the heap */
-/* At large sample rates, there's not enough stack space to run the demod */
-#define DEMOD_ALLOC_STACK
-
 /* This is a flag for the freq. estimator to use a precomputed/rt computed hann window table
    On platforms with slow cosf, this will produce a substantial speedup at the cost of a small
     amount of memory 
@@ -472,14 +468,8 @@ void fsk_demod_freq_est(struct FSK *fsk, COMP fsk_in[], float *freqs, int M) {
     int freqi[M];
     int st,en,f_zero;
     
-    /* Array to do complex FFT from using kiss_fft */
-    #ifdef DEMOD_ALLOC_STACK
-    kiss_fft_cpx *fftin  = (kiss_fft_cpx*)alloca(sizeof(kiss_fft_cpx)*Ndft);
-    kiss_fft_cpx *fftout = (kiss_fft_cpx*)alloca(sizeof(kiss_fft_cpx)*Ndft);
-    #else
     kiss_fft_cpx *fftin  = (kiss_fft_cpx*)malloc(sizeof(kiss_fft_cpx)*Ndft);
     kiss_fft_cpx *fftout = (kiss_fft_cpx*)malloc(sizeof(kiss_fft_cpx)*Ndft);
-    #endif
     
     st = (fsk->est_min*Ndft)/Fs + Ndft/2; if (st < 0) st = 0;
     en = (fsk->est_max*Ndft)/Fs + Ndft/2; if (en > Ndft) en = Ndft;
@@ -605,14 +595,13 @@ void fsk_demod_freq_est(struct FSK *fsk, COMP fsk_in[], float *freqs, int M) {
     //fprintf(stderr, "fsk->tone_spacing: %d\n",fsk->tone_spacing);
     for (int m=0; m<M; m++)
         fsk->f2_est[m] = foff + m*fsk->tone_spacing;
+
     #ifdef MODEMPROBE_ENABLE
     modem_probe_samp_f("t_f2_est",fsk->f2_est,M);
     #endif
 
-    #ifndef DEMOD_ALLOC_STACK
     free(fftin);
     free(fftout);
-    #endif
 }
 
 /* core demodulator function */

--- a/src/fsk_get_test_bits.c
+++ b/src/fsk_get_test_bits.c
@@ -29,7 +29,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <alloca.h>
 #include <string.h>
 #include "fsk.h"
 
@@ -70,11 +69,11 @@ int main(int argc,char *argv[]){
     
     if(fout==NULL){
         fprintf(stderr,"Couldn't open output file: %s\n", argv[1]);
-        goto cleanup;
+        exit(1);
     }
     
     /* allocate buffers for processing */
-    bitbuf = (uint8_t*)alloca(sizeof(uint8_t)*framesize);
+    bitbuf = (uint8_t*)malloc(sizeof(uint8_t)*framesize);
     
     /* Generate buffer of test frame bits from known seed */
     srand(158324);
@@ -91,7 +90,7 @@ int main(int argc,char *argv[]){
 	}
     }
     
- cleanup:
+    free(bitbuf);
     fclose(fout);
 
     return 0;

--- a/src/fsk_put_test_bits.c
+++ b/src/fsk_put_test_bits.c
@@ -29,7 +29,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <alloca.h>
 #include <string.h>
 #include <getopt.h>
 #include "fsk.h"
@@ -106,8 +105,8 @@ int main(int argc,char *argv[]){
     }
 
     /* allocate buffers for processing */
-    bitbuf_tx = (uint8_t*)alloca(sizeof(uint8_t)*framesize);
-    bitbuf_rx = (uint8_t*)alloca(sizeof(uint8_t)*framesize);
+    bitbuf_tx = (uint8_t*)malloc(sizeof(uint8_t)*framesize);
+    bitbuf_rx = (uint8_t*)malloc(sizeof(uint8_t)*framesize);
     
     /* Generate known tx frame from known seed */
     srand(158324);
@@ -154,6 +153,9 @@ int main(int argc,char *argv[]){
         }
     }
  
+    free(bitbuf_rx);
+    free(bitbuf_tx);
+
     fclose(fin);
 
     fprintf(stderr,"[%04d] BER %5.3f, bits tested %6d, bit errors %6d\n", packetcnt, ber, bitcnt, biterr);

--- a/unittest/test_700c_eq.sh
+++ b/unittest/test_700c_eq.sh
@@ -4,9 +4,9 @@
 
 results=$(mktemp)
 
-../build_linux/src/c2enc 700C ../raw/kristoff.raw /dev/null --var 2> $results
+c2enc 700C ../raw/kristoff.raw /dev/null --var 2> $results
 var=$(cat $results | sed -n "s/.*var: \([0-9..]*\) .*/\1/p")
-../build_linux/src/c2enc 700C ../raw/kristoff.raw /dev/null --var --eq 2> $results
+c2enc 700C ../raw/kristoff.raw /dev/null --var --eq 2> $results
 var_eq=$(cat $results | sed -n "s/.*var: \([0-9..]*\) .*/\1/p")
 printf "var: %5.2f var_eq: %5.2f\n" $var $var_eq
 python -c "import sys; sys.exit(0) if $var_eq<=$var else sys.exit(1)"

--- a/unittest/test_700c_eq.sh
+++ b/unittest/test_700c_eq.sh
@@ -4,9 +4,9 @@
 
 results=$(mktemp)
 
-c2enc 700C ../raw/kristoff.raw /dev/null --var 2> $results
+../build_linux/src/c2enc 700C ../raw/kristoff.raw /dev/null --var 2> $results
 var=$(cat $results | sed -n "s/.*var: \([0-9..]*\) .*/\1/p")
-c2enc 700C ../raw/kristoff.raw /dev/null --var --eq 2> $results
+../build_linux/src/c2enc 700C ../raw/kristoff.raw /dev/null --var --eq 2> $results
 var_eq=$(cat $results | sed -n "s/.*var: \([0-9..]*\) .*/\1/p")
 printf "var: %5.2f var_eq: %5.2f\n" $var $var_eq
 python -c "import sys; sys.exit(0) if $var_eq<=$var else sys.exit(1)"


### PR DESCRIPTION
These changes modify two ```fsk``` files using ```alloca()``` and changes them to ```malloc()/free()```.

The MSYS compiler header file ```stdlib.h``` also includes ```malloc.h```.

The use of ```alloca()``` would require a ```#ifdef```around the ```#include <alloca.h>```