### PR TITLE
include patch level in codec2/version.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ set(CODEC2_VERSION_MAJOR 1)
 set(CODEC2_VERSION_MINOR 0)
 # Set to patch level if needed, otherwise leave FALSE.
 # Must be positive (non-zero) if set, since 0 == FALSE in CMake.
-set(CODEC2_VERSION_PATCH 0)
+set(CODEC2_VERSION_PATCH 3)
 set(CODEC2_VERSION "${CODEC2_VERSION_MAJOR}.${CODEC2_VERSION_MINOR}")
 # Patch level version bumps should not change API/ABI.
 set(SOVERSION "${CODEC2_VERSION_MAJOR}.${CODEC2_VERSION_MINOR}")


### PR DESCRIPTION
In response to https://github.com/drowe67/codec2/issues/269, generates `codec2/version.h`:
```
#ifndef CODEC2_HAVE_VERSION
#define CODEC2_HAVE_VERSION

#define CODEC2_VERSION_MAJOR 1
#define CODEC2_VERSION_MINOR 0
#define CODEC2_VERSION_PATCH 3
#define CODEC2_VERSION "1.0.3"

#endif //CODEC2_HAVE_VERSION
```