### PR TITLE
Makefile for CML

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,6 +1,6 @@
 name: CMake
 
-on: [push, pull_request]
+on: [pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/octave/ldpc.m
+++ b/octave/ldpc.m
@@ -1,22 +1,25 @@
 % ldpc.m
 %
-% David Rowe 2013
-% Octave functions to help us use the CML LDPC code.
-%
-% Installing CML library
-% ----------------------
-%
-% $ sudo apt-get install liboctave-dev
-% $ wget http://www.iterativesolutions.com/user/image/cml.1.10.zip
-% $ unzip cml.1.10.zip
-% $ patch -p0 < ~/codec2/octave/cml.patch
-% $ cd cml/source
-% $ octave --no-gui
-% octave:> make
-% (you'll see a few warnings but hopefully no errors)
-%
-% Optionally set an environment variable for CML_PATH in your shell or
-% in your codec2/octave/.octaverc file
+#{
+  David Rowe 2013
+  Octave functions for the CML LDPC library.
+
+  To install and compile CML support:
+  
+  $ sudo apt-get install liboctave-dev
+  $ git clone git@github.com:drowe67/cml.git
+  $ cd cml
+  $ make
+
+  If you have configured codec2 with cmake -DUNITTEST=1, then you will
+  already have CML (e.g. under build_linux/cml), as it is used to run unit tests.
+
+  To use CML when running Octave simulations from the Octave CLI, set an
+  environment variable for CML_PATH in your shell or in your
+  codec2/octave/.octaverc file:
+
+    setenv("CML_PATH","../build_linux/cml")
+#}
 
 1;
 

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -105,10 +105,11 @@ include(ExternalProject)
 set(CML_PATH ${CMAKE_CURRENT_BINARY_DIR}/../cml)
 ExternalProject_Add(cml
    GIT_REPOSITORY https://github.com/drowe67/cml.git
+   GIT_TAG dr-makefile
    SOURCE_DIR ${CML_PATH}
    BUILD_IN_SOURCE 1
    CONFIGURE_COMMAND true # No configuration required
-   BUILD_COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/../cml/source && ${OCTAVE_CMD} -qf --eval "make"
+   BUILD_COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/../cml && make
    INSTALL_COMMAND true # No installation required
 )
 

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -105,7 +105,6 @@ include(ExternalProject)
 set(CML_PATH ${CMAKE_CURRENT_BINARY_DIR}/../cml)
 ExternalProject_Add(cml
    GIT_REPOSITORY https://github.com/drowe67/cml.git
-   GIT_TAG dr-makefile
    SOURCE_DIR ${CML_PATH}
    BUILD_IN_SOURCE 1
    CONFIGURE_COMMAND true # No configuration required


### PR DESCRIPTION
`codec2` side of https://github.com/drowe67/cml/pull/3 - prevent CML building mex files on every `codec2 make`.

We'll need to remove the `unittest/CMakeLists.txt GIT_TAG dr-makefile` before merging.

@tmiw can you please try this and tell me if it works OK for you?