### PR TITLE
Channel simulator maintenance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,7 +396,7 @@ if(UNITTEST)
     # check channel simulator measures correct Peak to Average Power Ratio (about 0dB) with a sine wave input signal
     add_test(NAME test_ch_papr
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR};
-                            ./misc/mksine - 1000 10 | ./src/ch - /dev/null -100  --ctest")
+                            ./misc/mksine - 1000 10 | ./src/ch - /dev/null --ctest")
 
     add_test(NAME test_codec2_700c_octave_port
              COMMAND sh -c "
@@ -418,11 +418,11 @@ if(UNITTEST)
              set_tests_properties(test_COHPSK_modem_octave_port PROPERTIES PASS_REGULAR_EXPRESSION "fails: 0")
 
     add_test(NAME test_COHPSK_modem_AWGN_BER
-             COMMAND sh -c "$<TARGET_FILE:cohpsk_get_test_bits> - 5600 | $<TARGET_FILE:cohpsk_mod> - - | $<TARGET_FILE:ch> - - -30 --Fs 7500 | $<TARGET_FILE:cohpsk_demod> - - | $<TARGET_FILE:cohpsk_put_test_bits> -"
+             COMMAND sh -c "$<TARGET_FILE:cohpsk_get_test_bits> - 5600 | $<TARGET_FILE:cohpsk_mod> - - | $<TARGET_FILE:ch> - - --No -30 --Fs 7500 | $<TARGET_FILE:cohpsk_demod> - - | $<TARGET_FILE:cohpsk_put_test_bits> -"
              )
 
     add_test(NAME test_COHPSK_modem_freq_offset
-             COMMAND sh -c "set -x; $<TARGET_FILE:cohpsk_get_test_bits> - 5600 | $<TARGET_FILE:cohpsk_mod> - - | $<TARGET_FILE:ch> - - -40 -f -30 --Fs 7500 | $<TARGET_FILE:cohpsk_demod> -v - - 2>log.txt | $<TARGET_FILE:cohpsk_put_test_bits> - ; ! grep 'lost sync' log.txt"
+             COMMAND sh -c "set -x; $<TARGET_FILE:cohpsk_get_test_bits> - 5600 | $<TARGET_FILE:cohpsk_mod> - - | $<TARGET_FILE:ch> - - --No -40 -f -30 --Fs 7500 | $<TARGET_FILE:cohpsk_demod> -v - - 2>log.txt | $<TARGET_FILE:cohpsk_put_test_bits> - ; ! grep 'lost sync' log.txt"
              )
 
     # -------------------------------------------------------------------------
@@ -523,7 +523,7 @@ if(UNITTEST)
                             ./fsk_put_test_bits - -q")
 
     add_test(NAME test_OFDM_modem_AWGN_BER
-             COMMAND sh -c "$<TARGET_FILE:ofdm_mod> --in /dev/zero --ldpc --testframes 60 --txbpf | $<TARGET_FILE:ch> - - -20  -f -50 | $<TARGET_FILE:ofdm_demod> --out /dev/null --testframes --ldpc --verbose 1"
+             COMMAND sh -c "$<TARGET_FILE:ofdm_mod> --in /dev/zero --ldpc --testframes 60 --txbpf | $<TARGET_FILE:ch> - - --No -20  -f -50 | $<TARGET_FILE:ofdm_demod> --out /dev/null --testframes --ldpc --verbose 1"
              )
 
     add_test(NAME test_OFDM_modem_fading_BER
@@ -552,7 +552,7 @@ endif()
     add_test(NAME test_OFDM_modem_700E_AWGN
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./ofdm_mod --in /dev/zero --testframes 10 --ldpc --mode 700E |
-                            ./ch - - -22 |
+                            ./ch - - --No -22 |
                             ./ofdm_demod --mode 700E --ldpc --testframes -v 2 > /dev/null")
 
     # -------------------------------------------------------------------------
@@ -603,7 +603,7 @@ endif()
     add_test(NAME test_OFDM_modem_datac0_ldpc_burst
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./ofdm_mod --mode datac0 --in /dev/zero --testframes 1 --verbose 1 --ldpc --bursts 3 |
-                            ./ch - - -17 |
+                            ./ch - - --No -17 |
                             ./ofdm_demod --mode datac0 --out /dev/null --testframes --ldpc --verbose 2 --packetsperburst 1")
 
     # -------------------------------------------------------------------------
@@ -712,7 +712,7 @@ endif()
     add_test(NAME test_freedv_api_700D_speech
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./freedv_tx 700D ../../raw/ve9qrp_10s.raw - |
-                            ./ch - - -20 |
+                            ./ch - - --No -20 |
                             ./freedv_rx 700D - /dev/null --squelch -2 -vv")
              set_tests_properties(test_freedv_api_700D_speech PROPERTIES PASS_REGULAR_EXPRESSION "frames decoded: 62  output speech samples: 7")
 
@@ -720,16 +720,16 @@ endif()
     add_test(NAME test_freedv_api_700D_burble
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./freedv_tx 700D ../../raw/ve9qrp.raw - |
-                            ./ch - - -8 |
+                            ./ch - - --No -8 |
                             ./freedv_rx 700D - /dev/null --squelch -2 -vv")
              set_tests_properties(test_freedv_api_700D_burble PROPERTIES PASS_REGULAR_EXPRESSION "output speech samples: 0")
 
     add_test(NAME test_freedv_api_700D_AWGN_BER
-             COMMAND sh -c "dd bs=2560 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:ch> - - -20  -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard"
+             COMMAND sh -c "dd bs=2560 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:ch> - - --No -20 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard"
              )
 
     add_test(NAME test_freedv_api_700D_AWGN_BER_USECOMPLEX
-             COMMAND sh -c "dd bs=2560 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:ch> - - -20  -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard --usecomplex"
+             COMMAND sh -c "dd bs=2560 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:ch> - - --No -20 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard --usecomplex"
              )
 
 if(LPCNET)
@@ -750,7 +750,7 @@ if(LPCNET)
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             dd bs=32000 count=10 if=/dev/zero |
                             ./freedv_tx 2020 - - --testframes |
-                            ./ch - - -24 |
+                            ./ch - - --No -24 |
                             ./freedv_rx 2020 - /dev/null --testframes"
              )
 endif()
@@ -822,21 +822,21 @@ endif()
 
    add_test(NAME test_freedv_reliable_text_awgn_1600
          COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
-                        ./freedv_tx 1600 ../../raw/ve9qrp.raw - --reliabletext AB1CDEF | ./ch - - -25 -f -5 > 1600_reliable.raw 2>/dev/null;
+                        ./freedv_tx 1600 ../../raw/ve9qrp.raw - --reliabletext AB1CDEF | ./ch - - --No -25 -f -5 > 1600_reliable.raw 2>/dev/null;
                         ./freedv_rx 1600 1600_reliable.raw /dev/null --txtrx 1600_reliable.txt --reliabletext 2>/dev/null;
                         if [ `cat 1600_reliable.txt | wc -l` -ge 10 ]; then echo 1; fi")
          set_tests_properties(test_freedv_reliable_text_awgn_1600 PROPERTIES PASS_REGULAR_EXPRESSION "1")
 
    add_test(NAME test_freedv_reliable_text_awgn_700D
       COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
-                     ./freedv_tx 700D ../../raw/ve9qrp.raw - --reliabletext AB1CDEF --txbpf 1 --clip 1 | ./ch - - -12 -f -5 > 700D_reliable.raw 2>/dev/null;
+                     ./freedv_tx 700D ../../raw/ve9qrp.raw - --reliabletext AB1CDEF --txbpf 1 --clip 1 | ./ch - - --No -12 -f -5 > 700D_reliable.raw 2>/dev/null;
                      ./freedv_rx 700D 700D_reliable.raw /dev/null --txtrx 700D_reliable.txt --reliabletext 2>/dev/null;
                      if [ `cat 700D_reliable.txt | wc -l` -ge 10 ]; then echo 1; fi")
       set_tests_properties(test_freedv_reliable_text_awgn_700D PROPERTIES PASS_REGULAR_EXPRESSION "1")
   
    add_test(NAME test_freedv_reliable_text_awgn_700E
        COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
-                      ./freedv_tx 700E ../../raw/ve9qrp.raw - --reliabletext AB1CDEF --txbpf 1 --clip 1 | ./ch - - -15 -f -5 > 700E_reliable.raw 2>/dev/null;
+                      ./freedv_tx 700E ../../raw/ve9qrp.raw - --reliabletext AB1CDEF --txbpf 1 --clip 1 | ./ch - - --No -15 -f -5 > 700E_reliable.raw 2>/dev/null;
                       ./freedv_rx 700E 700E_reliable.raw /dev/null --txtrx 700E_reliable.txt --reliabletext 2>/dev/null;
                       if [ `cat 700E_reliable.txt | wc -l` -ge 10 ]; then echo 1; fi")
        set_tests_properties(test_freedv_reliable_text_awgn_700E PROPERTIES PASS_REGULAR_EXPRESSION "1")
@@ -860,7 +860,7 @@ if(LPCNET)
                            
    add_test(NAME test_freedv_reliable_text_awgn_2020
          COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
-                        ./freedv_tx 2020 ../../raw/ve9qrp.raw - --reliabletext AB1CDEF | ./ch - - -22 -f -5 > 2020_reliable.raw 2>/dev/null;
+                        ./freedv_tx 2020 ../../raw/ve9qrp.raw - --reliabletext AB1CDEF | ./ch - - --No -22 -f -5 > 2020_reliable.raw 2>/dev/null;
                         ./freedv_rx 2020 2020_reliable.raw /dev/null --txtrx 2020_reliable.txt --reliabletext 2>/dev/null;
                         if [ `cat 2020_reliable.txt | wc -l` -ge 9 ]; then echo 1; fi")
          set_tests_properties(test_freedv_reliable_text_awgn_1600 PROPERTIES PASS_REGULAR_EXPRESSION "1")
@@ -1034,20 +1034,20 @@ endif(NOT APPLE)
      add_test(NAME test_fsk_2fsk_ber
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./fsk_get_test_bits - 10000 | ./fsk_mod 2 8000 100 1000 100 - - |
-                            ./ch - - -26 |
+                            ./ch - - --No -26 |
                             ./fsk_demod 2 8000 100 - - | ./fsk_put_test_bits -b 0.015 -q - ")
      # 4FSK modem at Eb/No = 6dB, SNR = Eb/No+10log10(Rb/B) = 6 + 10*log10(2*100/3000) = -5.7dB
      # Ideal BER = 0.016, set thresh 50% higher
      add_test(NAME test_fsk_4fsk_ber
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./fsk_get_test_bits - 10000 | ./fsk_mod 4 8000 100 1000 100 - - |
-                            ./ch - - -26 |
+                            ./ch - - --No -26 |
                             ./fsk_demod 4 8000 100 - - | ./fsk_put_test_bits -b 0.025 - ")
      # shift FSK signal to -ve frequencies
      add_test(NAME test_fsk_4fsk_ber_negative_freq
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./fsk_get_test_bits - 10000 | ./fsk_mod 4 8000 100 1000 200 - - |
-                            ./ch - - -26  --ssbfilt 0 --complexout -f -3000 |
+                            ./ch - - --No -26  --ssbfilt 0 --complexout -f -3000 |
                             ./fsk_demod -c -p 8 4 8000 100 - - |
                             ./fsk_put_test_bits -b 0.025 -q - ")
      # Low SNR 4FSK uncoded PER/BER test:
@@ -1059,7 +1059,7 @@ endif(NOT APPLE)
                             bits=512; tx_packets=20; rx_packets=18; tx_tone_sep=50; Rs=25;
                             ./fsk_get_test_bits - $(($bits*$tx_packets)) $bits |
                             ./fsk_mod 4 8000 $Rs 1000 $tx_tone_sep - - |
-                            ./ch - - -16 --ssbfilt 0 -f -3000 --complexout |
+                            ./ch - - --No -16 --ssbfilt 0 -f -3000 --complexout |
                             ./fsk_demod -c -p 8 --mask $tx_tone_sep -t1 --nsym 100 4 8000 $Rs - - 2>stats.txt |
                             ./fsk_put_test_bits -t 0.25 -b 0.20 -p $rx_packets -f $bits -q -")
 
@@ -1097,7 +1097,7 @@ endif(NOT APPLE)
                             ./ldpc_enc /dev/zero - --code HRAb_396_504 --testframes 200 |
                             ./framer - - 504 5186 |
                             ./fsk_mod 4 8000 100 1000 100 - - |
-                            ./ch - - -25 |
+                            ./ch - - --No -25 |
                             ./fsk_demod -s 4 8000 100 - - |
                             ./deframer - - 504 5186  |
                             ./ldpc_dec - /dev/null --code HRAb_396_504 --testframes")
@@ -1156,7 +1156,7 @@ endif(NOT APPLE)
      add_test(NAME test_freedv_data_raw_fsk_ldpc_100
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./freedv_data_raw_tx --testframes 10 --bursts 10 FSK_LDPC /dev/zero - |
-                            ./ch - - -5 --ssbfilt 0 |
+                            ./ch - - --No -5 --ssbfilt 0 |
                             ./freedv_data_raw_rx --testframes -v FSK_LDPC - /dev/null")
              set_tests_properties(test_freedv_data_raw_fsk_ldpc_100 PROPERTIES PASS_REGULAR_EXPRESSION "Frms.:    10")
 
@@ -1164,7 +1164,7 @@ endif(NOT APPLE)
      add_test(NAME test_freedv_data_raw_fsk_ldpc_1k
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./freedv_data_raw_tx --Fs 40000 --Rs 1000 --tone1 1000 --shift 1000 --testframes 10 --bursts 10 FSK_LDPC /dev/zero - |
-                            ./ch - - -10 --ssbfilt 0 |
+                            ./ch - - --No -10 --ssbfilt 0 |
                             ./freedv_data_raw_rx --testframes -v --Fs 40000 --Rs 1000 FSK_LDPC - /dev/null")
              set_tests_properties(test_freedv_data_raw_fsk_ldpc_1k PROPERTIES PASS_REGULAR_EXPRESSION "Frms.:    10")
 
@@ -1172,7 +1172,7 @@ endif(NOT APPLE)
      add_test(NAME test_freedv_data_raw_fsk_ldpc_10k
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./freedv_data_raw_tx --Fs 100000 --Rs 10000 --tone1 10000 --shift 10000 --framesperburst 100 --bursts 10 --testframes 1000 FSK_LDPC /dev/zero - |
-                            ./ch - - -15 --ssbfilt 0 |
+                            ./ch - - --No -15 --ssbfilt 0 |
                             ./freedv_data_raw_rx --testframes -v --Fs 100000 --Rs 10000 FSK_LDPC - /dev/null")
              set_tests_properties(test_freedv_data_raw_fsk_ldpc_10k PROPERTIES PASS_REGULAR_EXPRESSION "Frms.:  1000")
 
@@ -1180,7 +1180,7 @@ endif(NOT APPLE)
      add_test(NAME test_freedv_data_raw_fsk_ldpc_2k
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./freedv_data_raw_tx -a 8192 -m 4 --Fs 40000 --Rs 1000 --tone1 10000 --shift 2000 --testframes 10 --bursts 10 FSK_LDPC /dev/zero - |
-                             ./ch - - -22 --ssbfilt 0 |
+                             ./ch - - --No -22 --ssbfilt 0 |
                              ./freedv_data_raw_rx -m 4 --testframes -v --Fs 40000 --Rs 1000 FSK_LDPC --mask 2000 - /dev/null")
              set_tests_properties(test_freedv_data_raw_fsk_ldpc_2k PROPERTIES PASS_REGULAR_EXPRESSION "Frms.:    10")
 
@@ -1219,7 +1219,7 @@ endif(NOT APPLE)
       add_test(NAME test_demo_datac0c1
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR};
                             ./demo/freedv_datac0c1_tx | 
-                            ./src/ch - - -24 -f 20 | 
+                            ./src/ch - - --No -24 -f 20 | 
                             sox -t .s16 -c 1 -r 8000 - -t .s16 -c 1 -r 8008 - | 
                             ./demo/freedv_datac0c1_rx")
            set_tests_properties(test_demo_datac0c1 PROPERTIES PASS_REGULAR_EXPRESSION "DATAC0 Frames: 10 DATAC1 Frames: 10")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,9 +394,9 @@ if(UNITTEST)
              set_tests_properties(test_CML_ldpcut PROPERTIES PASS_REGULAR_EXPRESSION "Nerr: 0")
 
     # check channel simulator measures correct Peak to Average Power Ratio (about 0dB) with a sine wave input signal
-    add_test(NAME test_cohpsk_ch_papr
+    add_test(NAME test_ch_papr
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR};
-                            ./misc/mksine - 1000 10 | ./src/cohpsk_ch - /dev/null -100 --Fs 8000 --ctest")
+                            ./misc/mksine - 1000 10 | ./src/ch - /dev/null -100  --ctest")
 
     add_test(NAME test_codec2_700c_octave_port
              COMMAND sh -c "
@@ -418,11 +418,11 @@ if(UNITTEST)
              set_tests_properties(test_COHPSK_modem_octave_port PROPERTIES PASS_REGULAR_EXPRESSION "fails: 0")
 
     add_test(NAME test_COHPSK_modem_AWGN_BER
-             COMMAND sh -c "$<TARGET_FILE:cohpsk_get_test_bits> - 5600 | $<TARGET_FILE:cohpsk_mod> - - | $<TARGET_FILE:cohpsk_ch> - - -30  | $<TARGET_FILE:cohpsk_demod> - - | $<TARGET_FILE:cohpsk_put_test_bits> -"
+             COMMAND sh -c "$<TARGET_FILE:cohpsk_get_test_bits> - 5600 | $<TARGET_FILE:cohpsk_mod> - - | $<TARGET_FILE:ch> - - -30 --Fs 7500 | $<TARGET_FILE:cohpsk_demod> - - | $<TARGET_FILE:cohpsk_put_test_bits> -"
              )
 
     add_test(NAME test_COHPSK_modem_freq_offset
-             COMMAND sh -c "set -x; $<TARGET_FILE:cohpsk_get_test_bits> - 5600 | $<TARGET_FILE:cohpsk_mod> - - | $<TARGET_FILE:cohpsk_ch> - - -40 -f -30 | $<TARGET_FILE:cohpsk_demod> -v - - 2>log.txt | $<TARGET_FILE:cohpsk_put_test_bits> - ; ! grep 'lost sync' log.txt"
+             COMMAND sh -c "set -x; $<TARGET_FILE:cohpsk_get_test_bits> - 5600 | $<TARGET_FILE:cohpsk_mod> - - | $<TARGET_FILE:ch> - - -40 -f -30 --Fs 7500 | $<TARGET_FILE:cohpsk_demod> -v - - 2>log.txt | $<TARGET_FILE:cohpsk_put_test_bits> - ; ! grep 'lost sync' log.txt"
              )
 
     # -------------------------------------------------------------------------
@@ -523,7 +523,7 @@ if(UNITTEST)
                             ./fsk_put_test_bits - -q")
 
     add_test(NAME test_OFDM_modem_AWGN_BER
-             COMMAND sh -c "$<TARGET_FILE:ofdm_mod> --in /dev/zero --ldpc --testframes 60 --txbpf | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -50 | $<TARGET_FILE:ofdm_demod> --out /dev/null --testframes --ldpc --verbose 1"
+             COMMAND sh -c "$<TARGET_FILE:ofdm_mod> --in /dev/zero --ldpc --testframes 60 --txbpf | $<TARGET_FILE:ch> - - -20  -f -50 | $<TARGET_FILE:ofdm_demod> --out /dev/null --testframes --ldpc --verbose 1"
              )
 
     add_test(NAME test_OFDM_modem_fading_BER
@@ -552,7 +552,7 @@ endif()
     add_test(NAME test_OFDM_modem_700E_AWGN
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./ofdm_mod --in /dev/zero --testframes 10 --ldpc --mode 700E |
-                            ./cohpsk_ch - - -22 --Fs 8000 |
+                            ./ch - - -22 |
                             ./ofdm_demod --mode 700E --ldpc --testframes -v 2 > /dev/null")
 
     # -------------------------------------------------------------------------
@@ -603,7 +603,7 @@ endif()
     add_test(NAME test_OFDM_modem_datac0_ldpc_burst
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./ofdm_mod --mode datac0 --in /dev/zero --testframes 1 --verbose 1 --ldpc --bursts 3 |
-                            ./cohpsk_ch - - -17 --Fs 8000 |
+                            ./ch - - -17 |
                             ./ofdm_demod --mode datac0 --out /dev/null --testframes --ldpc --verbose 2 --packetsperburst 1")
 
     # -------------------------------------------------------------------------
@@ -712,7 +712,7 @@ endif()
     add_test(NAME test_freedv_api_700D_speech
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./freedv_tx 700D ../../raw/ve9qrp_10s.raw - |
-                            ./cohpsk_ch - - -20 --Fs 8000 |
+                            ./ch - - -20 |
                             ./freedv_rx 700D - /dev/null --squelch -2 -vv")
              set_tests_properties(test_freedv_api_700D_speech PROPERTIES PASS_REGULAR_EXPRESSION "frames decoded: 62  output speech samples: 7")
 
@@ -720,16 +720,16 @@ endif()
     add_test(NAME test_freedv_api_700D_burble
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./freedv_tx 700D ../../raw/ve9qrp.raw - |
-                            ./cohpsk_ch - - -8 --Fs 8000 |
+                            ./ch - - -8 |
                             ./freedv_rx 700D - /dev/null --squelch -2 -vv")
              set_tests_properties(test_freedv_api_700D_burble PROPERTIES PASS_REGULAR_EXPRESSION "output speech samples: 0")
 
     add_test(NAME test_freedv_api_700D_AWGN_BER
-             COMMAND sh -c "dd bs=2560 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard"
+             COMMAND sh -c "dd bs=2560 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:ch> - - -20  -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard"
              )
 
     add_test(NAME test_freedv_api_700D_AWGN_BER_USECOMPLEX
-             COMMAND sh -c "dd bs=2560 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:cohpsk_ch> - - -20 --Fs 8000 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard --usecomplex"
+             COMMAND sh -c "dd bs=2560 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:ch> - - -20  -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard --usecomplex"
              )
 
 if(LPCNET)
@@ -750,7 +750,7 @@ if(LPCNET)
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             dd bs=32000 count=10 if=/dev/zero |
                             ./freedv_tx 2020 - - --testframes |
-                            ./cohpsk_ch - - -24 --Fs 8000 |
+                            ./ch - - -24 |
                             ./freedv_rx 2020 - /dev/null --testframes"
              )
 endif()
@@ -822,21 +822,21 @@ endif()
 
    add_test(NAME test_freedv_reliable_text_awgn_1600
          COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
-                        ./freedv_tx 1600 ../../raw/ve9qrp.raw - --reliabletext AB1CDEF | ./cohpsk_ch - - -25 --Fs 8000 -f -5 > 1600_reliable.raw 2>/dev/null;
+                        ./freedv_tx 1600 ../../raw/ve9qrp.raw - --reliabletext AB1CDEF | ./ch - - -25 -f -5 > 1600_reliable.raw 2>/dev/null;
                         ./freedv_rx 1600 1600_reliable.raw /dev/null --txtrx 1600_reliable.txt --reliabletext 2>/dev/null;
                         if [ `cat 1600_reliable.txt | wc -l` -ge 10 ]; then echo 1; fi")
          set_tests_properties(test_freedv_reliable_text_awgn_1600 PROPERTIES PASS_REGULAR_EXPRESSION "1")
 
    add_test(NAME test_freedv_reliable_text_awgn_700D
       COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
-                     ./freedv_tx 700D ../../raw/ve9qrp.raw - --reliabletext AB1CDEF --txbpf 1 --clip 1 | ./cohpsk_ch - - -12 --Fs 8000 -f -5 > 700D_reliable.raw 2>/dev/null;
+                     ./freedv_tx 700D ../../raw/ve9qrp.raw - --reliabletext AB1CDEF --txbpf 1 --clip 1 | ./ch - - -12 -f -5 > 700D_reliable.raw 2>/dev/null;
                      ./freedv_rx 700D 700D_reliable.raw /dev/null --txtrx 700D_reliable.txt --reliabletext 2>/dev/null;
                      if [ `cat 700D_reliable.txt | wc -l` -ge 10 ]; then echo 1; fi")
       set_tests_properties(test_freedv_reliable_text_awgn_700D PROPERTIES PASS_REGULAR_EXPRESSION "1")
   
    add_test(NAME test_freedv_reliable_text_awgn_700E
        COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
-                      ./freedv_tx 700E ../../raw/ve9qrp.raw - --reliabletext AB1CDEF --txbpf 1 --clip 1 | ./cohpsk_ch - - -15 --Fs 8000 -f -5 > 700E_reliable.raw 2>/dev/null;
+                      ./freedv_tx 700E ../../raw/ve9qrp.raw - --reliabletext AB1CDEF --txbpf 1 --clip 1 | ./ch - - -15 -f -5 > 700E_reliable.raw 2>/dev/null;
                       ./freedv_rx 700E 700E_reliable.raw /dev/null --txtrx 700E_reliable.txt --reliabletext 2>/dev/null;
                       if [ `cat 700E_reliable.txt | wc -l` -ge 10 ]; then echo 1; fi")
        set_tests_properties(test_freedv_reliable_text_awgn_700E PROPERTIES PASS_REGULAR_EXPRESSION "1")
@@ -860,7 +860,7 @@ if(LPCNET)
                            
    add_test(NAME test_freedv_reliable_text_awgn_2020
          COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
-                        ./freedv_tx 2020 ../../raw/ve9qrp.raw - --reliabletext AB1CDEF | ./cohpsk_ch - - -22 --Fs 8000 -f -5 > 2020_reliable.raw 2>/dev/null;
+                        ./freedv_tx 2020 ../../raw/ve9qrp.raw - --reliabletext AB1CDEF | ./ch - - -22 -f -5 > 2020_reliable.raw 2>/dev/null;
                         ./freedv_rx 2020 2020_reliable.raw /dev/null --txtrx 2020_reliable.txt --reliabletext 2>/dev/null;
                         if [ `cat 2020_reliable.txt | wc -l` -ge 9 ]; then echo 1; fi")
          set_tests_properties(test_freedv_reliable_text_awgn_1600 PROPERTIES PASS_REGULAR_EXPRESSION "1")
@@ -1034,20 +1034,20 @@ endif(NOT APPLE)
      add_test(NAME test_fsk_2fsk_ber
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./fsk_get_test_bits - 10000 | ./fsk_mod 2 8000 100 1000 100 - - |
-                            ./cohpsk_ch - - -26 --Fs 8000 |
+                            ./ch - - -26 |
                             ./fsk_demod 2 8000 100 - - | ./fsk_put_test_bits -b 0.015 -q - ")
      # 4FSK modem at Eb/No = 6dB, SNR = Eb/No+10log10(Rb/B) = 6 + 10*log10(2*100/3000) = -5.7dB
      # Ideal BER = 0.016, set thresh 50% higher
      add_test(NAME test_fsk_4fsk_ber
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./fsk_get_test_bits - 10000 | ./fsk_mod 4 8000 100 1000 100 - - |
-                            ./cohpsk_ch - - -26 --Fs 8000 |
+                            ./ch - - -26 |
                             ./fsk_demod 4 8000 100 - - | ./fsk_put_test_bits -b 0.025 - ")
      # shift FSK signal to -ve frequencies
      add_test(NAME test_fsk_4fsk_ber_negative_freq
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./fsk_get_test_bits - 10000 | ./fsk_mod 4 8000 100 1000 200 - - |
-                            ./cohpsk_ch - - -26 --Fs 8000 --ssbfilt 0 --complexout -f -3000 |
+                            ./ch - - -26  --ssbfilt 0 --complexout -f -3000 |
                             ./fsk_demod -c -p 8 4 8000 100 - - |
                             ./fsk_put_test_bits -b 0.025 -q - ")
      # Low SNR 4FSK uncoded PER/BER test:
@@ -1059,7 +1059,7 @@ endif(NOT APPLE)
                             bits=512; tx_packets=20; rx_packets=18; tx_tone_sep=50; Rs=25;
                             ./fsk_get_test_bits - $(($bits*$tx_packets)) $bits |
                             ./fsk_mod 4 8000 $Rs 1000 $tx_tone_sep - - |
-                            ./cohpsk_ch - - -16 --Fs 8000 --ssbfilt 0 -f -3000 --complexout |
+                            ./ch - - -16 --ssbfilt 0 -f -3000 --complexout |
                             ./fsk_demod -c -p 8 --mask $tx_tone_sep -t1 --nsym 100 4 8000 $Rs - - 2>stats.txt |
                             ./fsk_put_test_bits -t 0.25 -b 0.20 -p $rx_packets -f $bits -q -")
 
@@ -1097,7 +1097,7 @@ endif(NOT APPLE)
                             ./ldpc_enc /dev/zero - --code HRAb_396_504 --testframes 200 |
                             ./framer - - 504 5186 |
                             ./fsk_mod 4 8000 100 1000 100 - - |
-                            ./cohpsk_ch - - -25 --Fs 8000  |
+                            ./ch - - -25 |
                             ./fsk_demod -s 4 8000 100 - - |
                             ./deframer - - 504 5186  |
                             ./ldpc_dec - /dev/null --code HRAb_396_504 --testframes")
@@ -1156,7 +1156,7 @@ endif(NOT APPLE)
      add_test(NAME test_freedv_data_raw_fsk_ldpc_100
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./freedv_data_raw_tx --testframes 10 --bursts 10 FSK_LDPC /dev/zero - |
-                            ./cohpsk_ch - - -5 --Fs 8000 --ssbfilt 0 |
+                            ./ch - - -5 --ssbfilt 0 |
                             ./freedv_data_raw_rx --testframes -v FSK_LDPC - /dev/null")
              set_tests_properties(test_freedv_data_raw_fsk_ldpc_100 PROPERTIES PASS_REGULAR_EXPRESSION "Frms.:    10")
 
@@ -1164,7 +1164,7 @@ endif(NOT APPLE)
      add_test(NAME test_freedv_data_raw_fsk_ldpc_1k
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./freedv_data_raw_tx --Fs 40000 --Rs 1000 --tone1 1000 --shift 1000 --testframes 10 --bursts 10 FSK_LDPC /dev/zero - |
-                            ./cohpsk_ch - - -10 --Fs 8000 --ssbfilt 0 |
+                            ./ch - - -10 --ssbfilt 0 |
                             ./freedv_data_raw_rx --testframes -v --Fs 40000 --Rs 1000 FSK_LDPC - /dev/null")
              set_tests_properties(test_freedv_data_raw_fsk_ldpc_1k PROPERTIES PASS_REGULAR_EXPRESSION "Frms.:    10")
 
@@ -1172,7 +1172,7 @@ endif(NOT APPLE)
      add_test(NAME test_freedv_data_raw_fsk_ldpc_10k
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./freedv_data_raw_tx --Fs 100000 --Rs 10000 --tone1 10000 --shift 10000 --framesperburst 100 --bursts 10 --testframes 1000 FSK_LDPC /dev/zero - |
-                            ./cohpsk_ch - - -15 --Fs 8000 --ssbfilt 0 |
+                            ./ch - - -15 --ssbfilt 0 |
                             ./freedv_data_raw_rx --testframes -v --Fs 100000 --Rs 10000 FSK_LDPC - /dev/null")
              set_tests_properties(test_freedv_data_raw_fsk_ldpc_10k PROPERTIES PASS_REGULAR_EXPRESSION "Frms.:  1000")
 
@@ -1180,7 +1180,7 @@ endif(NOT APPLE)
      add_test(NAME test_freedv_data_raw_fsk_ldpc_2k
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/src;
                             ./freedv_data_raw_tx -a 8192 -m 4 --Fs 40000 --Rs 1000 --tone1 10000 --shift 2000 --testframes 10 --bursts 10 FSK_LDPC /dev/zero - |
-                             ./cohpsk_ch - - -22 --Fs 8000 --ssbfilt 0 |
+                             ./ch - - -22 --ssbfilt 0 |
                              ./freedv_data_raw_rx -m 4 --testframes -v --Fs 40000 --Rs 1000 FSK_LDPC --mask 2000 - /dev/null")
              set_tests_properties(test_freedv_data_raw_fsk_ldpc_2k PROPERTIES PASS_REGULAR_EXPRESSION "Frms.:    10")
 
@@ -1219,7 +1219,7 @@ endif(NOT APPLE)
       add_test(NAME test_demo_datac0c1
              COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR};
                             ./demo/freedv_datac0c1_tx | 
-                            ./src/cohpsk_ch - - -24 -f 20 --Fs 8000 | 
+                            ./src/ch - - -24 -f 20 | 
                             sox -t .s16 -c 1 -r 8000 - -t .s16 -c 1 -r 8008 - | 
                             ./demo/freedv_datac0c1_rx")
            set_tests_properties(test_demo_datac0c1 PROPERTIES PASS_REGULAR_EXPRESSION "DATAC0 Frames: 10 DATAC1 Frames: 10")

--- a/README_cohpsk.md
+++ b/README_cohpsk.md
@@ -7,7 +7,7 @@
 1. BER test in AWGN channel with just less that 2% average bit error rate:
 
    ```
-    $ ./cohpsk_get_test_bits - 5600 | ./cohpsk_mod - - | ./cohpsk_ch - - -30 | ./cohpsk_demod - - | ./cohpsk_put_test_bits -
+    $ ./cohpsk_get_test_bits - 5600 | ./cohpsk_mod - - | ./ch - - --No -30 --Fs 7500 | ./cohpsk_demod - - | ./cohpsk_put_test_bits -
     <snip>
     SNR3k(dB):  3.41 C/No: 38.2 PAPR:  8.1 
     BER: 0.017 Nbits: 5264 Nerrors: 92
@@ -18,7 +18,7 @@
 
    ```
     $ cd build_linux/src
-    $ ./cohpsk_get_test_bits - 5600 | ./cohpsk_mod - -  | ./cohpsk_ch - - -40 -f -20 | ./cohpsk_demod -o cohpsk_demod.txt - - | ./cohpsk_put_test_bits -
+    $ ./cohpsk_get_test_bits - 5600 | ./cohpsk_mod - -  | ./ch - - --No -40 -f -20 --Fs 7500 | ./cohpsk_demod -o cohpsk_demod.txt - - | ./cohpsk_put_test_bits -
     $ cd ../../octave
     $ octave --no-gui
     $ cohpsk_demod_plot("../build_linux/src/cohpsk_demod.txt")    

--- a/README_freedv.md
+++ b/README_freedv.md
@@ -174,27 +174,27 @@ $ ./freedv_tx 2020 ~/LPCNet/wav/all.wav - --testframes | ./freedv_rx 2020 - /dev
 
 Simulated HF slow fading channel, 10.8dB SNR:
 ```
-$ ./freedv_tx 2020 ~/LPCNet/wav/all.wav - | ./cohpsk_ch - - -30 --Fs 8000 --slow | ./freedv_rx 2020 - - | aplay -f S16_LE -r 16000
+$ ./freedv_tx 2020 ~/LPCNet/wav/all.wav - | ./ch - - --No -30 --slow | ./freedv_rx 2020 - - | aplay -f S16_LE -r 16000
 ```
 It falls down quite a bit with fast fading (--fast):
 
 AWGN (noise but no fading) channel, 2.8dB SNR:
 ```
-$ ./freedv_tx 2020 ~/LPCNet/wav/all.wav - | ./cohpsk_ch - - -22 --Fs 8000 | ./freedv_rx 2020 - - | aplay -f S16_LE -r 16000
+$ ./freedv_tx 2020 ~/LPCNet/wav/all.wav - | ./ch - - --No -22 | ./freedv_rx 2020 - - | aplay -f S16_LE -r 16000
 ```
 
 ## Command lines for PER testing 700D/700E PER with clipper
 
 AWGN:
 ```
-$ ./src/freedv_tx 700D ../raw/ve9qrp.raw - --clip 0 --testframes | ./src/cohpsk_ch - - -16 --Fs 8000 | ./src/freedv_rx 700D - /dev/null --testframes
+$ ./src/freedv_tx 700D ../raw/ve9qrp.raw - --clip 0 --testframes | ./src/ch - - --No -16 | ./src/freedv_rx 700D - /dev/null --testframes
 ```
 MultiPath Poor (MPP):
 ```
-$ ./src/freedv_tx 700D ../raw/ve9qrp.raw - --clip 0 --testframes | ./src/cohpsk_ch - - -24 --mpp --fading_dir unittest --Fs 8000 | ./src/freedv_rx 700D - /dev/null --testframes
+$ ./src/freedv_tx 700D ../raw/ve9qrp.raw - --clip 0 --testframes | ./src/ch - - --No -24 --mpp --fading_dir unittest| ./src/freedv_rx 700D - /dev/null --testframes
 ```
 
-Adjust `--clip [0|1]` and 3rd argument of `cohpsk_ch` to obtain a PER of just less than 0.1, and note the SNR and PAPR reported by `cohpsk_ch`.  The use of the `ve9qrp` samples makes the test run for a few minutes, in order to get reasonable multipath channel results.
+Adjust `--clip [0|1]` and `No` argument of `ch` to obtain a PER of just less than 0.1, and note the SNR and PAPR reported by `ch`.  The use of the `ve9qrp` samples makes the test run for a few minutes, in order to get reasonable multipath channel results.
 
 ## Reading Further
 

--- a/README_freedv.md
+++ b/README_freedv.md
@@ -191,7 +191,7 @@ $ ./src/freedv_tx 700D ../raw/ve9qrp.raw - --clip 0 --testframes | ./src/ch - - 
 ```
 MultiPath Poor (MPP):
 ```
-$ ./src/freedv_tx 700D ../raw/ve9qrp.raw - --clip 0 --testframes | ./src/ch - - --No -24 --mpp --fading_dir unittest| ./src/freedv_rx 700D - /dev/null --testframes
+$ ./src/freedv_tx 700D ../raw/ve9qrp.raw - --clip 0 --testframes | ./src/ch - - --No -24 --mpp --fading_dir unittest | ./src/freedv_rx 700D - /dev/null --testframes
 ```
 
 Adjust `--clip [0|1]` and `No` argument of `ch` to obtain a PER of just less than 0.1, and note the SNR and PAPR reported by `ch`.  The use of the `ve9qrp` samples makes the test run for a few minutes, in order to get reasonable multipath channel results.

--- a/README_fsk.md
+++ b/README_fsk.md
@@ -77,7 +77,7 @@ The Octave version of the modem was developed by David Rowe.  Brady O'Brien port
    $ cd ~/codec2/build_linux/src
    $ ./ldpc_enc /dev/zero - --code H_256_512_4 --testframes 200 |
      ./framer - - 512 5186 | ./fsk_mod 4 8000 100 1000 100 - - |
-     ./ch - - --No -24  |
+     ./ch - - --No -24 |
      ./fsk_demod -s 4 8000 100 - - |
      ./deframer - - 512 5186  |
      ./ldpc_dec - /dev/null --code H_256_512_4 --testframes

--- a/README_fsk.md
+++ b/README_fsk.md
@@ -49,13 +49,13 @@ The Octave version of the modem was developed by David Rowe.  Brady O'Brien port
 
 1. Lets add some channel noise:
    ```
-   $ ./fsk_get_test_bits - 10000 | ./fsk_mod 2 8000 100 1200 100 - - | ./cohpsk_ch - - -26 --Fs 8000 | ./fsk_demod 2 8000 100 - - | ./fsk_put_test_bits -b 0.015 -
+   $ ./fsk_get_test_bits - 10000 | ./fsk_mod 2 8000 100 1200 100 - - | ./ch - - --No -26 | ./fsk_demod 2 8000 100 - - | ./fsk_put_test_bits -b 0.015 -
    <snip>
    SNR3k(dB): -5.76 C/No: 29.0 PAPR:  3.0 
    [0099] BER 0.010, bits tested   9900, bit errors  103
    PASS
    ```
-   The cohpsk_ch utility takes the FSK modulator signal, and adds calibrated noise to it (the -26 value specifies the noise).  Try changing the noise level, and note how the Bit Error Rate (BER) changes.  The BER is 0.01, which is right on theory for this sort of FSK demodulator at this SNR (2FSK non-coherent demodulator Eb/No=9dB).  
+   The `ch` utility takes the FSK modulator signal, and adds calibrated noise to it (the `--No -26` value specifies the noise).  Try changing the noise level, and note how the Bit Error Rate (BER) changes.  The BER is 0.01, which is right on theory for this sort of FSK demodulator at this SNR (2FSK non-coherent demodulator Eb/No=9dB).  
 
    The SNR is calculated using the signal power divided by the noise power in 3000 Hz.  The C/No value is the same thing, but uses a noise bandwidth of 1 Hz.  There is less noise power when you look at just 1Hz, so C/No is higher. Peak to Average Power ratio (PAPR) is 3dB as a FSK signal is just a single sine wave, and a sine wave peak is 3dB higher than it's average.
 
@@ -77,7 +77,7 @@ The Octave version of the modem was developed by David Rowe.  Brady O'Brien port
    $ cd ~/codec2/build_linux/src
    $ ./ldpc_enc /dev/zero - --code H_256_512_4 --testframes 200 |
      ./framer - - 512 5186 | ./fsk_mod 4 8000 100 1000 100 - - |
-     ./cohpsk_ch - - -24 --Fs 8000  |
+     ./ch - - --No -24  |
      ./fsk_demod -s 4 8000 100 - - |
      ./deframer - - 512 5186  |
      ./ldpc_dec - /dev/null --code H_256_512_4 --testframes

--- a/README_ofdm.md
+++ b/README_ofdm.md
@@ -79,36 +79,36 @@ Built as part of codec2-dev, see [README](README.md) for build instructions.
 
 1. Listen to signal through simulated fading channel in C:
    ```
-   build_linux/src$ ./c2enc 700C ../../raw/ve9qrp_10s.raw - --bitperchar | ./ofdm_mod --ldpc | ./cohpsk_ch - - -20 --Fs 8000 --slow -f -5 | aplay -f S16
+   build_linux/src$ ./c2enc 700C ../../raw/ve9qrp_10s.raw - --bitperchar | ./ofdm_mod --ldpc | ./ch - - --No -20 --mpg -f -5 | aplay -f S16
    ```
 
 1. Run test frames through simulated channel in C:
    ```
-   build_linux/src$ ./ofdm_mod --in /dev/zero --ldpc --testframes 20 | ./cohpsk_ch - - -24 --Fs 8000 -f -10 --fast | ./ofdm_demod --out /dev/null --testframes --verbose 1 --ldpc
+   build_linux/src$ ./ofdm_mod --in /dev/zero --ldpc --testframes 20 | ./ch - - --No -24 -f -10 --mpp | ./ofdm_demod --out /dev/null --testframes --verbose 1 --ldpc
    ```
 
 1. Run codec voice through simulated fast fading channel, just where it starts to fall over:
    ```
-   build_linux/src$ ./c2enc 700C ../../raw/ve9qrp.raw - --bitperchar | ./ofdm_mod --ldpc | ./cohpsk_ch - - -24 --Fs 8000 -f -10 --fast | ./ofdm_demod --ldpc --verbose 1 | ./c2dec 700C - - --bitperchar | aplay -f S16
+   build_linux/src$ ./c2enc 700C ../../raw/ve9qrp.raw - --bitperchar | ./ofdm_mod --ldpc | ./ch - - --No -24 -f -10 --mpp | ./ofdm_demod --ldpc --verbose 1 | ./c2dec 700C - - --bitperchar | aplay -f S16
    ```
 
 1. FreeDV 1600 on the same channel conditions, roughly same quality at 8dB higher SNR:
    ```
-   build_linux/src$ ./freedv_tx 1600 ../../raw/ve9qrp_10s.raw - | ./cohpsk_ch - - -30 --Fs 8000 -f -10 --fast | ./freedv_rx 1600 - - | aplay -f S16
+   build_linux/src$ ./freedv_tx 1600 ../../raw/ve9qrp_10s.raw - | ./ch - - --No -30 -f -10 --mpp | ./freedv_rx 1600 - - | aplay -f S16
    ```
 
 1. Using FreeDV API test programs:
    ```
    build_linux/src$ ./freedv_tx 700D ../../raw/hts1a.raw - --testframes | ./freedv_rx 700D - /dev/null --testframes
    build_linux/src$ ./freedv_tx 700D ../../raw/hts1a.raw - | ./freedv_rx 700D - - | aplay -f S16
-   build_linux/src$ ./freedv_tx 700D ../../raw/ve9qrp.raw - | ./cohpsk_ch - - -26 --Fs 8000 -f -10 --fast | ./freedv_rx 700D - - | aplay -f S16
+   build_linux/src$ ./freedv_tx 700D ../../raw/ve9qrp.raw - | ./ch - - --No -26 -f -10 --mpp | ./freedv_rx 700D - - | aplay -f S16
    ```
 
 ## FreeDV 2020 extensions
 
 1.  20.5ms symbol period, 31 carrier waveform, (504,396) code, but only 312 data bits used, so we don't send unused data bits.  This means we need less carriers (so more power per carrier), and code rate is increased slightly:
     ```
-    build_linux/src$ ./ofdm_mod --in /dev/zero --testframes 300 --mode 2020 --ldpc 1 --verbose 1 -p 312 | ./cohpsk_ch - - -22 --Fs 8000 -f 10 --ssbfilt 1 | ./ofdm_demod --out /dev/null --testframes --mode 2020 --verbose 1 --ldpc -p 312
+    build_linux/src$ ./ofdm_mod --in /dev/zero --testframes 300 --mode 2020 --ldpc 1 --verbose 1 -p 312 | ./ch - - --No -22 -f 10 --ssbfilt 1 | ./ofdm_demod --out /dev/null --testframes --mode 2020 --verbose 1 --ldpc -p 312
 
     SNR3k(dB):  2.21 C/No: 37.0 PAPR:  9.6
     BER......: 0.0505 Tbits: 874020 Terrs: 44148
@@ -156,7 +156,7 @@ Here are some useful tests for the LDPC coded C version of the modem, useful to 
 
 1. AWGN channel, -2dB:
    ```
-   ./ofdm_mod --in /dev/zero --ldpc --testframes 60 --txbpf | ./cohpsk_ch - - -20 --Fs 8000 -f -10 | ./ofdm_demod --out /dev/null --testframes --verbose 1 --ldpc
+   ./ofdm_mod --in /dev/zero --ldpc --testframes 60 --txbpf | ./ch - - --No -20 -f -10 | ./ofdm_demod --out /dev/null --testframes --verbose 1 --ldpc
 
    SNR3k(dB): -1.85 C/No: 32.9 PAPR:  9.8
    BER......: 0.0815 Tbits: 98532 Terrs:  8031
@@ -165,7 +165,7 @@ Here are some useful tests for the LDPC coded C version of the modem, useful to 
 
 1. Fading HF channel:
    ```
-   ./ofdm_mod --in /dev/zero --ldpc --testframes 60 --txbpf | ./cohpsk_ch - - -24 --Fs 8000 -f -10 --fast | ./ofdm_demod --out /dev/null --testframes --verbose 1 --ldpc
+   ./ofdm_mod --in /dev/zero --ldpc --testframes 60 --txbpf | ./ch - - --No -24 -f -10 --fast | ./ofdm_demod --out /dev/null --testframes --verbose 1 --ldpc
 
    SNR3k(dB):  2.15 C/No: 36.9 PAPR:  9.8
    BER......: 0.1015 Tbits: 88774 Terrs:  9012
@@ -181,7 +181,7 @@ The OFDM modem can also support datac1/datac2/datac3 modes for packet data.  The
 Here is an example of running the datac3 mode in a low SNR AWGN channel:
 
 ```
-./src/ofdm_mod --mode datac3 --ldpc --in  /dev/zero --testframes 60 --verbose 1 | ./src/cohpsk_ch - - -20 --Fs 8000 | ./src/ofdm_demod --mode datac3 --ldpc --out /dev/null --testframes -v 1
+./src/ofdm_mod --mode datac3 --ldpc --in  /dev/zero --testframes 60 --verbose 1 | ./src/ch - - --No -20 | ./src/ofdm_demod --mode datac3 --ldpc --out /dev/null --testframes -v 1
 <snip>
 SNR3k(dB): -3.54 C/No: 31.2 PAPR: 10.4
 BER......: 0.1082 Tbits: 36096 Terrs:  3905 Tpackets:    47
@@ -200,7 +200,7 @@ Note despite the raw BER of 10%, 47/50 packets are received error free.
 | ofdm_demod | OFDM demodulator command line program, supports uncoded (raw) and LDPC coded test frames, LDPC decoding of codec data, and can output LLRs to external LDPC decoder |
 | ofdm_put_test_bits | Measure BER in OFDM test frames |
 | unittest/tofdm | Run C port of modem to compare with octave version (see octave/tofdm) |
-| cohpsk_ch | From COHPSK modem development, useful C channel simulator |
+| ch | C channel simulator |
 
 # Octave Scripts
 

--- a/octave/ch_fading.m
+++ b/octave/ch_fading.m
@@ -1,10 +1,10 @@
-% cohpsk_ch_fading.m
+% ch_fading.m
 % David Rowe
 % April 2018
 
 % function to write float fading samples for use by C programs
 
-function cohpsk_ch_fading(raw_file_name, Fs, dopplerSpreadHz, len_samples)
+function ch_fading(raw_file_name, Fs, dopplerSpreadHz, len_samples)
   randn('seed',1);
   spread = doppler_spread(dopplerSpreadHz, Fs, len_samples);
   spread_2ms = doppler_spread(dopplerSpreadHz, Fs, len_samples);

--- a/octave/cohpsk_demod_plot.m
+++ b/octave/cohpsk_demod_plot.m
@@ -5,7 +5,7 @@
 % when errors hit the system
 
 #{
-   $ ./cohpsk_get_test_bits - 5600 | ./cohpsk_mod - - | ./cohpsk_ch - - -40 | ./cohpsk_demod - - -o cohpsk_demod.txt | ./cohpsk_put_test_bits -
+   $ ./cohpsk_get_test_bits - 5600 | ./cohpsk_mod - - | ./ch - - --No -40 | ./cohpsk_demod - - -o cohpsk_demod.txt | ./cohpsk_put_test_bits -
    octave> cohpsk_demod_plot("../build_linux/src/cohpsk_demod.txt")
 #}
    

--- a/octave/fsk_demod_file.m
+++ b/octave/fsk_demod_file.m
@@ -14,7 +14,7 @@
 
    Same thing but complex (single sided):
    
-   $ ./fsk_get_test_bits - 1000 | ./fsk_mod 2 8000 100 1000 1000 - - | ./cohpsk_ch - fsk.cs16 -100 --Fs 8000 --complexout
+   $ ./fsk_get_test_bits - 1000 | ./fsk_mod 2 8000 100 1000 1000 - - | ./ch - fsk.cs16 --complexout
    octave:2> fsk_demod_file("fsk.cs16",format="cs16",8000,100,2)
 #}
 

--- a/octave/make_ssbfilt.m
+++ b/octave/make_ssbfilt.m
@@ -1,7 +1,7 @@
 % make_ssbfilt.m
 % David Rowe May 2015
 %
-% Creates low pass filter coeff used to implement a SSB filter in cohpsk_ch
+% Creates low pass filter coeff used to implement a SSB filter in ch
 
 graphics_toolkit ("gnuplot");
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -379,8 +379,8 @@ target_link_libraries(cohpsk_get_test_bits ${CMAKE_REQUIRED_LIBRARIES} codec2)
 add_executable(cohpsk_put_test_bits cohpsk_put_test_bits.c octave.c)
 target_link_libraries(cohpsk_put_test_bits ${CMAKE_REQUIRED_LIBRARIES} codec2)
 
-add_executable(cohpsk_ch cohpsk_ch.c)
-target_link_libraries(cohpsk_ch ${CMAKE_REQUIRED_LIBRARIES} codec2)
+add_executable(ch ch.c)
+target_link_libraries(ch ${CMAKE_REQUIRED_LIBRARIES} codec2)
 
 add_executable(tollr tollr.c)
 

--- a/src/ch.c
+++ b/src/ch.c
@@ -9,7 +9,7 @@
 \*---------------------------------------------------------------------------*/
 
 /*
-  Copyright (C) 2015 David Rowe
+  Copyright (C) 2015-2022 David Rowe
 
   All rights reserved.
 
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <math.h>
 #include <errno.h>
+#include <getopt.h>
 
 #include "freedv_api.h"
 #include "codec2_cohpsk.h"
@@ -51,16 +52,6 @@
 #define MPG_FADING_FILE_NAME  "slow_fading_samples.float"
 #define MPP_FADING_FILE_NAME  "fast_fading_samples.float"
 #define MPD_FADING_FILE_NAME  "faster_fading_samples.float"
-
-int opt_exists(char *argv[], int argc, char opt[]) {
-    int i;
-    for (i=0; i<argc; i++) {
-        if (strcmp(argv[i], opt) == 0) {
-            return i;
-        }
-    }
-    return 0;
-}
 
 // Gaussian from uniform:
 float gaussian(void) {
@@ -99,52 +90,119 @@ int main(int argc, char *argv[])
     int            frames, i, j, k, Fs, ret, nclipped, noutclipped, ssbfilt_en, complex_out, ctest;
     float          sam, peak, clip, papr, CNo, snr3k, gain;
 
-    if (argc > 3) {
-        if (strcmp(argv[1], "-")  == 0) fin = stdin;
-        else if ( (fin = fopen(argv[1],"rb")) == NULL ) {
-            fprintf(stderr, "cohpsk_ch: Error opening input modem raw file: %s: %s.\n",
-                    argv[1], strerror(errno));
-            exit(1);
-        }
-
-        if (strcmp(argv[2], "-") == 0) fout = stdout;
-        else if ( (fout = fopen(argv[2],"wb")) == NULL ) {
-            fprintf(stderr, "cohpsk_ch: Error opening output modem raw file: %s: %s.\n",
-                    argv[2], strerror(errno));
-            exit(1);
-        }
-
-        NodB = atof(argv[3]);
-        Fs = 8000; foff_hz = 0.0; fading_en = 0; ctest = 0;
-        clip =32767; gain = 1.0;
-        ssbfilt_en = 1; complex_out = 0;
-        fading_dir = strdup(DEFAULT_FADING_DIR); user_multipath_delay = -1.0;
-
-        for(int i=4; i<argc; i++) {
-            if (!strcmp(argv[i],"--Fs")) { Fs = atoi(argv[i+1]); i++; }
-            else if (!strcmp(argv[i], "-f")) { foff_hz = atoi(argv[i+1]); i++; }
-            else if (!strcmp(argv[i], "--mpg")) fading_en = 1;
-            else if (!strcmp(argv[i], "--mpp")) fading_en = 2;
-            else if (!strcmp(argv[i], "--mpd")) fading_en = 3;
-            else if (!strcmp(argv[i], "--gain")) { gain = atof(argv[i+1]); i++; }
-            else if (!strcmp(argv[i], "--clip")) { clip = atof(argv[i+1]); i++; }
-            else if (!strcmp(argv[i], "--ssbfilt")) { ssbfilt_en = atof(argv[i+1]); i++; }
-            else if (!strcmp(argv[i], "--complexout")) complex_out = 1;
-            else if (!strcmp(argv[i], "--ctest")) ctest = 1;
-            else if (!strcmp(argv[i], "--multipath_delay")) { user_multipath_delay = atof(argv[i+1]); i++; }
-            else if (!strcmp(argv[i], "--fading_dir")) {
-                FREE(fading_dir); fading_dir = strdup(argv[i+1]); i++;
-            } else {
-                fprintf(stderr, "Unknown argument: %s\n", argv[i]);
-                exit(1);
-            }
-        }
-    }
-    else {
-        fprintf(stderr, "usage: %s InputRealModemRawFile OutputRealModemRawFile No(dB/Hz) [--Fs SampleRateHz]"
-                        " [-f FoffHz] [--mpg] [--mpp] [--mpd] [--clip 0to1] [--ssbfilt 0|1] [--fading_dir Path]"
-                        " [--complexout] [--mulipath_delay ms]\n", argv[0]);
+    if (argc < 3) {
+    helpmsg:
+        fprintf(stderr, "usage: %s InputRealModemRawFile OutputRealModemRawFile [Options]\n"
+                        "\n"
+                        "  real int16 input -> Gain -> Hilbert Transform -> clipper -> freq shift ->\n"
+                        "  Multipath -> AWGN noise -> SSB filter -> real int16 output\n"
+                        "\n"
+                        "[--clip int16]         Hilbert clipper (clip complex signal magnitude, default 32767)\n"
+                        "[--complexout]         Optional int16 IQ complex output (default real)\n"
+                        "[--ctest]              Check PAPR is around 0dB, used to support ctests\n"
+                        "[--freqq FoffHz]       Frequency offset (default 0Hz)\n"
+                        "[--fading_dir Path]    path to multipath fading files (default 'unittest')\n"
+                        "[--Fs SampleRateHz]    Sample rate of simulation (default 8000 Hz)\n"
+                        "[--gain G]             Linear gain (default 1.0)\n"
+                        "[--mpg]                Multipath good 0.1Hz Doppler, 0.5ms delay\n"
+                        "[--mpp]                Multipath poor 1.0Hz Doppler, 1.0ms delay\n"
+                        "[--mpd]                Multipath disturbed 2.0Hz Doppler, 2.0ms delay\n"
+                        "[--ssbfilt 0|1]        SSB bandwidth filter (default 1 on)\n"
+                        "[--mulipath_delay ms]  Optionally adjust multipath delay\n"
+                        "[--No dBHz]            AWGN Noise density dB/Hz (default -100)"
+                        "\n"
+                , argv[0]);
         exit(1);
+    }
+
+    if (strcmp(argv[1], "-")  == 0) fin = stdin;
+    else if ( (fin = fopen(argv[1],"rb")) == NULL ) {
+        fprintf(stderr, "ch: Error opening input modem raw file: %s: %s.\n",
+                argv[1], strerror(errno));
+        exit(1);
+    }
+
+    if (strcmp(argv[2], "-") == 0) fout = stdout;
+    else if ( (fout = fopen(argv[2],"wb")) == NULL ) {
+        fprintf(stderr, "ch: Error opening output modem raw file: %s: %s.\n",
+                argv[2], strerror(errno));
+        exit(1);
+    }
+
+    NodB = -100;
+    Fs = 8000; foff_hz = 0.0; fading_en = 0; ctest = 0;
+    clip =32767; gain = 1.0;
+    ssbfilt_en = 1; complex_out = 0;
+    fading_dir = strdup(DEFAULT_FADING_DIR); user_multipath_delay = -1.0;
+
+    int o = 0;
+    int opt_idx = 0;
+    while( o != -1 ){
+        static struct option long_opts[] = {
+            {"complexout",      no_argument,        0, 'o'},
+            {"ctest",           no_argument,        0, 't'},
+            {"clip",            required_argument,  0, 'c'},
+            {"fading_dir",      required_argument,  0, 'u'},
+            {"freq",            required_argument,  0, 'f'},
+            {"Fs",              required_argument,  0, 'r'},
+            {"gain",            required_argument,  0, 'g'},
+            {"ssbfilt",         required_argument,  0, 's'},
+            {"help",            no_argument,        0, 'h'},
+            {"mpg",             no_argument,        0, 'i'},
+            {"mpp",             no_argument,        0, 'p'},
+            {"mpd",             no_argument,        0, 'd'},
+            {"multipath_delay", required_argument,  0, 'm'},
+            {"No",              required_argument,  0, 'n'},
+            {0, 0, 0, 0}
+        };
+
+        o = getopt_long(argc,argv,"c:df:g:im:n:opr:s:tu:h",long_opts,&opt_idx);
+        
+        switch(o) {
+        case 'c':
+            clip = atof(optarg);
+            break;
+        case 'd':
+            fading_en = 3;
+            break;
+        case 'f':
+            foff_hz = atof(optarg);
+            break;
+        case 'g':
+            gain = atof(optarg);
+            break;
+        case 'i':
+            fading_en = 1;
+            break;
+        case 'm':
+            user_multipath_delay = atof(optarg);
+            break;
+        case 'n':
+            NodB = atof(optarg);
+            break;
+        case 'o':
+            complex_out = 1;
+            break;
+        case 'p':
+            fading_en = 2;
+            break;
+        case 'r':
+            Fs = atoi(optarg);
+            break;
+        case 's':
+            ssbfilt_en = atoi(optarg);
+            break;
+        case 't':
+            ctest = 1;
+            break;
+        case 'u':
+            fading_dir = strdup(optarg);
+            break;
+        case 'h':
+        case '?':
+            goto helpmsg;
+            break;
+        }
     }
 
     phase_ch.real = 1.0; phase_ch.imag = 0.0;
@@ -173,7 +231,7 @@ int main(int argc, char *argv[])
             if (ffading == NULL) {
             cant_load_fading_file:
                 fprintf(stderr, "-----------------------------------------------------\n");
-                fprintf(stderr, "cohpsk_ch ERROR: Can't find fading file: %s\n", fname);
+                fprintf(stderr, "ch ERROR: Can't find fading file: %s\n", fname);
                 fprintf(stderr, "\nAdjust path --fading_dir or use GNU Octave to generate:\n\n");
             gen_fading_file:
                 fprintf(stderr, "$ octave --no-gui\n");

--- a/src/ch.c
+++ b/src/ch.c
@@ -1,11 +1,10 @@
 /*---------------------------------------------------------------------------*\
 
-  FILE........: cohpsk_ch.c
+  FILE........: ch.c
   AUTHOR......: David Rowe
   DATE CREATED: May 2015
 
-  Channel impairment program for testing command line versions of
-  cohpsk (and other) modems.
+  Channel impairment program for testing command line versions of modems.
 
 \*---------------------------------------------------------------------------*/
 
@@ -46,9 +45,9 @@
 #define MPP_DELAY_MS     2.0
 #define MPD_DELAY_MS     4.0
 
-/* see instructions below for how to generate thsese files */
+/* see instructions below for how to generate these files */
 
-#define DEFAULT_FADING_DIR    ""
+#define DEFAULT_FADING_DIR    "unittest"
 #define MPG_FADING_FILE_NAME  "slow_fading_samples.float"
 #define MPP_FADING_FILE_NAME  "fast_fading_samples.float"
 #define MPD_FADING_FILE_NAME  "faster_fading_samples.float"
@@ -65,10 +64,10 @@ int opt_exists(char *argv[], int argc, char opt[]) {
 
 // Gaussian from uniform:
 float gaussian(void) {
-	  double x = (double)rand() / RAND_MAX;
+    double x = (double)rand() / RAND_MAX;
     double y = (double)rand() / RAND_MAX;
     double z = sqrt(-2 * log(x)) * cos(2 * M_PI * y);
-	  return sqrt(1./2.) * z;
+    return sqrt(1./2.) * z;
 }
 
 // complex noise sample
@@ -116,7 +115,7 @@ int main(int argc, char *argv[])
         }
 
         NodB = atof(argv[3]);
-        Fs = COHPSK_FS; foff_hz = 0.0; fading_en = 0; ctest = 0;
+        Fs = 8000; foff_hz = 0.0; fading_en = 0; ctest = 0;
         clip =32767; gain = 1.0;
         ssbfilt_en = 1; complex_out = 0;
         fading_dir = strdup(DEFAULT_FADING_DIR); user_multipath_delay = -1.0;
@@ -241,7 +240,7 @@ int main(int argc, char *argv[])
 
     frames = 0;
     while(fread(buf, sizeof(short), BUF_N, fin) == BUF_N) {
-	      frames++;
+        frames++;
 
         /* Hilbert Transform to produce complex signal so we can do
            single sided freq shifts, HF channel modemsl, and analog compression.
@@ -273,25 +272,24 @@ int main(int argc, char *argv[])
 
         /* --------------------------------------------------------*\
    	                    Clipping  mag of complex signal
-   	    \*---------------------------------------------------------*/
+        \*---------------------------------------------------------*/
 
         for(i=0; i<BUF_N; i++) {
             float mag = sqrt(ch_in[i].real*ch_in[i].real + ch_in[i].imag*ch_in[i].imag);
-            //fprintf(stdout, "%f\n",mag);
             float angle = atan2(ch_in[i].imag, ch_in[i].real);
             if (mag > clip) {
               mag = clip;
               nclipped++;
             }
             tx_pwr += mag*mag;
-            if (mag > peak) peak = mag;
+            if (mag > peak) { peak = mag; /*fprintf(stderr, "%f\n",mag);*/ }
             ch_in[i].real = mag*cos(angle);
             ch_in[i].imag = mag*sin(angle);
         }
 
-	      /* --------------------------------------------------------*\
-	                               Channel
-	      \*---------------------------------------------------------*/
+	/* --------------------------------------------------------*\
+	                         Channel
+	\*---------------------------------------------------------*/
 
         fdmdv_freq_shift_coh(ch_fdm, ch_in, foff_hz, Fs, &phase_ch, BUF_N);
 
@@ -371,11 +369,11 @@ int main(int argc, char *argv[])
 
         int nout = (complex_out+1)*BUF_N;
         short bufout[nout], *pout=bufout;
-	      for(i=0; i<BUF_N; i++) {
+        for(i=0; i<BUF_N; i++) {
             sam = ssbfiltout[i].real;
             if (sam >  32767.0) { noutclipped++; sam = 32767.0; }
             if (sam < -32767.0) { noutclipped++; sam = -32767.0; }
-	          *pout++ = sam;
+            *pout++ = sam;
             if (complex_out) {
                 sam = ssbfiltout[i].imag;
                 if (sam >  32767.0) { noutclipped++; sam = 32767.0; }
@@ -384,10 +382,10 @@ int main(int argc, char *argv[])
             }
         }
 
- 	      fwrite(bufout, sizeof(short), nout, fout);
+        fwrite(bufout, sizeof(short), nout, fout);
 
-	      /* if this is in a pipeline, we probably don't want the usual
-	         buffering to occur */
+        /* if this is in a pipeline, we probably don't want the usual
+           buffering to occur */
 
         if (fout == stdout) fflush(stdout);
     }

--- a/src/ch.c
+++ b/src/ch.c
@@ -237,9 +237,9 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "$ octave --no-gui\n");
                 fprintf(stderr, "octave:24> pkg load signal\n");
                 fprintf(stderr, "octave:24> time_secs=60\n");
-                fprintf(stderr, "octave:25> cohpsk_ch_fading(\"faster_fading_samples.float\", 8000, 2.0, 8000*time_secs)\n");
-                fprintf(stderr, "octave:26> cohpsk_ch_fading(\"fast_fading_samples.float\", 8000, 1.0, 8000*time_secs)\n");
-                fprintf(stderr, "octave:27> cohpsk_ch_fading(\"slow_fading_samples.float\", 8000, 0.1, 8000*time_secs)\n");
+                fprintf(stderr, "octave:25> ch_fading(\"faster_fading_samples.float\", 8000, 2.0, 8000*time_secs)\n");
+                fprintf(stderr, "octave:26> ch_fading(\"fast_fading_samples.float\", 8000, 1.0, 8000*time_secs)\n");
+                fprintf(stderr, "octave:27> ch_fading(\"slow_fading_samples.float\", 8000, 0.1, 8000*time_secs)\n");
                 fprintf(stderr, "-----------------------------------------------------\n");
                 exit(1);
             }
@@ -289,7 +289,7 @@ int main(int argc, char *argv[])
     lo_freq.real = cos(2.0*M_PI*SSBFILT_CENTRE/Fs);
     lo_freq.imag = sin(2.0*M_PI*SSBFILT_CENTRE/Fs);
 
-    fprintf(stderr, "cohpsk_ch: Fs: %d NodB: %4.2f foff: %4.2f Hz fading: %d nhfdelay: %d clip: %4.2f ssbfilt: %d complexout: %d\n",
+    fprintf(stderr, "ch: Fs: %d NodB: %4.2f foff: %4.2f Hz fading: %d nhfdelay: %d clip: %4.2f ssbfilt: %d complexout: %d\n",
             Fs, NodB, foff_hz, fading_en, nhfdelay, clip, ssbfilt_en, complex_out);
 
     /* --------------------------------------------------------*\
@@ -368,12 +368,12 @@ int main(int argc, char *argv[])
             for(i=0; i<BUF_N; i++) {
                 ret = fread(&aspread, sizeof(COMP), 1, ffading);
                 if (ret == 0) {
-                    fprintf(stderr, "cohpsk_ch: Fading file finished - simulation stopping.  You may need more samples:\n");
+                    fprintf(stderr, "ch: Fading file finished - simulation stopping.  You may need more samples:\n");
                     goto gen_fading_file;
                     }
                 ret = fread(&aspread_2ms, sizeof(COMP), 1, ffading);
                 if (ret == 0) {
-                    fprintf(stderr, "cohpsk_ch: Fading file finished - simulation stopping.  You may need more samples:\n");
+                    fprintf(stderr, "ch: Fading file finished - simulation stopping.  You may need more samples:\n");
                     goto gen_fading_file;
                 }
                 //printf("%f %f %f %f\n", aspread.real, aspread.imag, aspread_2ms.real, aspread_2ms.imag);
@@ -456,11 +456,11 @@ int main(int argc, char *argv[])
     CNo = 10*log10(tx_pwr/(noise_pwr/(Fs)));
     snr3k = CNo - 10*log10(3000);
     float outclipped_percent = noutclipped*100.0/nsamples;
-    fprintf(stderr, "cohpsk_ch: SNR3k(dB): %8.2f  C/No....: %8.2f\n", snr3k, CNo);
-    fprintf(stderr, "cohpsk_ch: peak.....: %8.2f  RMS.....: %8.2f   CPAPR.....: %5.2f \n", peak, sqrt(tx_pwr/nsamples), papr);
-    fprintf(stderr, "cohpsk_ch: Nsamples.: %8d  clipped.: %8.2f%%  OutClipped: %5.2f%%\n",
+    fprintf(stderr, "ch: SNR3k(dB): %8.2f  C/No....: %8.2f\n", snr3k, CNo);
+    fprintf(stderr, "ch: peak.....: %8.2f  RMS.....: %8.2f   CPAPR.....: %5.2f \n", peak, sqrt(tx_pwr/nsamples), papr);
+    fprintf(stderr, "ch: Nsamples.: %8d  clipped.: %8.2f%%  OutClipped: %5.2f%%\n",
                     nsamples, nclipped*100.0/nsamples, outclipped_percent);
-    if (outclipped_percent > 0.1) fprintf(stderr, "cohpsk_ch: WARNING output clipping\n");
+    if (outclipped_percent > 0.1) fprintf(stderr, "ch: WARNING output clipping\n");
 
     if (ffading != NULL) fclose(ffading);
     if (ch_fdm_delay != NULL) FREE(ch_fdm_delay);

--- a/unittest/fading_files.sh
+++ b/unittest/fading_files.sh
@@ -4,10 +4,10 @@
 
 output_path=$1
 echo "Generating fading files ......"
-cmd='cd ../octave; pkg load signal; cohpsk_ch_fading("'${output_path}'/fast_fading_samples.float", 8000, 1.0, 8000*60)'
+cmd='cd ../octave; pkg load signal; ch_fading("'${output_path}'/fast_fading_samples.float", 8000, 1.0, 8000*60)'
 octave --no-gui -qf --eval "$cmd"
 [ ! $? -eq 0 ] && { echo "octave failed to run correctly .... exiting"; exit 1; }
-cmd='cd ../octave; pkg load signal; cohpsk_ch_fading("'${output_path}'/faster_fading_samples.float", 8000, 2.0, 8000*60)'
+cmd='cd ../octave; pkg load signal; ch_fading("'${output_path}'/faster_fading_samples.float", 8000, 2.0, 8000*60)'
 octave --no-gui -qf --eval "$cmd"
 [ ! $? -eq 0 ] && { echo "octave failed to run correctly .... exiting"; exit 1; }
 exit 0

--- a/unittest/fading_files.sh
+++ b/unittest/fading_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
 #
 # Generate fading files used for channel simulation
 

--- a/unittest/ofdm_fade.sh
+++ b/unittest/ofdm_fade.sh
@@ -6,7 +6,7 @@
 results=$(mktemp)
 fading_dir=$1
 # BER should be around 4% for this test (it's better for larger interleavers but no one uses interleaving in practice)
-ofdm_mod --in /dev/zero --ldpc 1 --testframes 60 --txbpf | cohpsk_ch - - -24 --Fs 8000 -f -10 --mpp --fading_dir $fading_dir | ofdm_demod --out /dev/null --testframes --verbose 2 --ldpc 1 2> $results
+ofdm_mod --in /dev/zero --ldpc 1 --testframes 60 --txbpf | ch - - --No -24 -f -10 --mpp --fading_dir $fading_dir | ofdm_demod --out /dev/null --testframes --verbose 2 --ldpc 1 2> $results
 cat $results
 cber=$(cat $results | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")
 python3 -c "import sys; sys.exit(0) if $cber<=0.05 else sys.exit(1)"

--- a/unittest/ofdm_fade.sh
+++ b/unittest/ofdm_fade.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
 #
 # David June 2019
 # Tests 700D OFDM modem fading channel performance, using a simulated channel

--- a/unittest/ofdm_fade_dpsk.sh
+++ b/unittest/ofdm_fade_dpsk.sh
@@ -8,7 +8,7 @@ results=$(mktemp)
 
 # Coded BER should be < 1% for this test
 ofdm_mod --in /dev/zero --testframes 300 --mode 2020 --ldpc --verbose 1 -p 312 --dpsk | \
-cohpsk_ch - - -40 --Fs 8000 -f 10 --ssbfilt 1 --mpd --fading_dir $fading_dir --multipath_delay 2 | \
+ch - - --No -40 -f 10 --ssbfilt 1 --mpd --fading_dir $fading_dir --multipath_delay 2 | \
 ofdm_demod --out /dev/null --testframes --mode 2020 --verbose 1 --ldpc -p 312 --dpsk 2> $results
 cat $results
 cber=$(cat $results | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")

--- a/unittest/ofdm_fade_dpsk.sh
+++ b/unittest/ofdm_fade_dpsk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
 #
 # David Sep 2019
 # Tests 2020 OFDM modem fading channel performance in DPSK mode, using a simulated faster (2Hz) high SNR fading channel

--- a/unittest/ofdm_phase_est_bw.sh
+++ b/unittest/ofdm_phase_est_bw.sh
@@ -17,7 +17,7 @@ results=$(mktemp)
 fading_dir=$1
 # BER should be < 5% for this test
 ofdm_mod --in /dev/zero --testframes 300 --mode 2020 --ldpc -p 312 --verbose 0 | \
-cohpsk_ch - - -40 --Fs 8000 -f 10 --ssbfilt 1 --mpp --fading_dir $fading_dir | \
+ch - - --No -40 -f 10 --ssbfilt 1 --mpp --fading_dir $fading_dir | \
 ofdm_demod --out /dev/null --testframes --mode 2020 --verbose 2 --ldpc -p 312 --bandwidth 1 2> $results
 cat $results
 cber=$(cat $results | sed -n "s/^Coded BER.* \([0-9..]*\) Tbits.*/\1/p")

--- a/unittest/ofdm_phase_est_bw.sh
+++ b/unittest/ofdm_phase_est_bw.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
 #
 # ofdm_phase_est_bw.sh
 # David August 2019

--- a/unittest/ofdm_time_sync.sh
+++ b/unittest/ofdm_time_sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Shell script version of ofdm_time_sync()
 # David June 2019
 # Tests ofdm modem sync time, using real, off air files

--- a/unittest/ota_auto.sh
+++ b/unittest/ota_auto.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
 # ota_auto.sh
 #
 # Run a single automated test and log results

--- a/unittest/ota_last.sh
+++ b/unittest/ota_last.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Present summary info from the n-th latest OTA HF data test
 

--- a/unittest/ota_summary.sh
+++ b/unittest/ota_summary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Summarise tests to date
 

--- a/unittest/ota_test.sh
+++ b/unittest/ota_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ota_test.sh
 #
 # Automated Over The Air (OTA) data test for FreeDV OFDM HF data modems

--- a/unittest/ota_voice_auto.sh
+++ b/unittest/ota_voice_auto.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
 # ota_voice_auto.sh
 #
 # Run a single automated voice test, files are put in a time stamped directory, and summarised in single line

--- a/unittest/ota_voice_summary.sh
+++ b/unittest/ota_voice_summary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Summarise tests to date into one directory to allow easy browsing
 

--- a/unittest/ota_voice_test.sh
+++ b/unittest/ota_voice_test.sh
@@ -52,10 +52,10 @@ function analog_compressor {
     input_file=$1
     output_file=$2
     gain=$3
-    cat $input_file | cohpsk_ch - - -100 --Fs 8000 2>/dev/null | \
-    cohpsk_ch - - -100 --Fs 8000 --clip 16384 --gain $gain 2>/dev/null | \
+    cat $input_file | ch - - 2>/dev/null | \
+    ch - - --No -100 --clip 16384 --gain $gain 2>/dev/null | \
     # final line prints peak and CPAPR for SSB
-    cohpsk_ch - - -100 --Fs 8000 --clip 16384 |
+    ch - - --clip 16384 |
     # manually adjusted to get similar peak levels for SSB and FreeDV
     sox -t .s16 -r 8000 -c 1 -v 0.85 - -t .s16 $output_file
 }
@@ -201,8 +201,8 @@ cat $speech_comp $speech_freedv > tx.raw
 sox -t .s16 -r 8000 -c 1 tx.raw tx.wav
 
 if [ $txstats -eq 1 ]; then
-    # cohpsk_ch just used to monitor observe peak and RMS level
-    cohpsk_ch $speech_freedv /dev/null -100
+    # ch just used to monitor observe peak and RMS level
+    ch $speech_freedv /dev/null
     # time domain plot of tx signal
     echo "pkg load signal; warning('off', 'all'); \
           s=load_raw('tx.raw'); plot(s); \

--- a/unittest/ota_voice_test.sh
+++ b/unittest/ota_voice_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ota_test.sh
 #
 # Automated Over The Air (OTA) voice test for FreeDV HF voice modes

--- a/unittest/reliable_text_fade.sh
+++ b/unittest/reliable_text_fade.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
 #
 # Tests reliable_text fading channel performance, using a simulated channel
 

--- a/unittest/reliable_text_fade.sh
+++ b/unittest/reliable_text_fade.sh
@@ -18,7 +18,7 @@ else
     clip_args=
 fi
 
-$tx $mode ../raw/ve9qrp.raw - --reliabletext AB1CDEF $clip_args | $build_folder/cohpsk_ch - - $snr --mpp --Fs 8000 -f -5 --fading_dir $fading_dir > $results/reliable_fade.raw 
+$tx $mode ../raw/ve9qrp.raw - --reliabletext AB1CDEF $clip_args | $build_folder/ch - - --No $snr --mpp -f -5 --fading_dir $fading_dir > $results/reliable_fade.raw 
 $rx $mode $results/reliable_fade.raw /dev/null --txtrx $results/reliable_fade.txt --reliabletext
 if [ `cat $results/reliable_fade.txt | wc -l` -ge $min_text_packets ]; then
     exit 0

--- a/unittest/test_700c_eq.sh
+++ b/unittest/test_700c_eq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # test_700c_eq.sh
 # make sure 700C EQ is reducing VQ distortion
 

--- a/unittest/tnc1_high_snr.sh
+++ b/unittest/tnc1_high_snr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # tnc1_high_snr.sh
 #
 #  HF TNC use case test 1

--- a/unittest/tnc4_high_snr_ping.sh
+++ b/unittest/tnc4_high_snr_ping.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
 # tnc4_high_snr_ping.sh
 #
 #  HF TNC use case test 4


### PR DESCRIPTION
1. Change name from `cohpsk_ch` to `ch` as it's used for all modems.
2. Make default Fs 8000
3. Use `getopt()` for command line arguments

`getopt` appears to choke on negative no-optional arguments like;
```
ch in.raw out.raw -30
```
So I had to change everything to:
```
ch in.raw out.raw --No -30
```
Hmm, on second thoughts that's not so bad, makes the usage a bit cleaner in some cases.