### PR TITLE
added cmake files for cross compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,23 @@ wav         - speech files in wave file format
 
 ## Building for Windows on a Linux machine
 
-On Ubuntu 17 and above:
+On Ubuntu 20.04 LTS( 32bit ):
    ```
-   sudo apt-get install mingw-w64
+   sudo apt install mingw-w64 g++-mingw-w64
    mkdir build_windows && cd build_windows
-   cmake .. -DCMAKE_TOOLCHAIN_FILE=/home/david/freedv-dev/cmake/Toolchain-Ubuntu-mingw32.cmake -DUNITTEST=FALSE -DGENERATE_CODEBOOK=/home/david/codec2/build_linux/src/generate_codebook 
+   cmake -DCMAKE_TOOLCHAIN_FILE=~/Toolchain-Ubuntu-mingw32.cmake .. 
    make
    ```
+
+On Ubuntu 20.04 LTS ( 64bit ):
+   ```
+   sudo apt install mingw-w64 g++-mingw-w64
+   mkdir build_windows && cd build_windows
+   cmake -DCMAKE_TOOLCHAIN_FILE=~/Toolchain-Ubuntu-mingw64.cmake .. 
+   make
+   ```   
+   
+   
    
 ## Building for Windows on a Windows machine
 

--- a/README.md
+++ b/README.md
@@ -195,19 +195,19 @@ wav         - speech files in wave file format
 
 ## Building for Windows on a Linux machine
 
-On Ubuntu 20.04 LTS( 32bit ):
+On Ubuntu 20.04 LTS ( for 32bit Windows):
    ```
    sudo apt install mingw-w64 g++-mingw-w64
    mkdir build_windows && cd build_windows
-   cmake -DCMAKE_TOOLCHAIN_FILE=~/Toolchain-Ubuntu-mingw32.cmake .. 
+   cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-Ubuntu-mingw32.cmake .. 
    make
    ```
 
-On Ubuntu 20.04 LTS ( 64bit ):
+On Ubuntu 20.04 LTS ( for 64bit Windows):
    ```
    sudo apt install mingw-w64 g++-mingw-w64
    mkdir build_windows && cd build_windows
-   cmake -DCMAKE_TOOLCHAIN_FILE=~/Toolchain-Ubuntu-mingw64.cmake .. 
+   cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-Ubuntu-mingw64.cmake .. 
    make
    ```   
    

--- a/cmake/Toolchain-Ubuntu-mingw32.cmake
+++ b/cmake/Toolchain-Ubuntu-mingw32.cmake
@@ -1,0 +1,25 @@
+# Sample toolchain file for building for Windows from an Ubuntu Linux system.
+#
+# Typical usage:
+#    *) install cross compiler: `sudo apt-get install mingw-w64 g++-mingw-w64`
+#    *) cd build
+#    *) cmake -DCMAKE_TOOLCHAIN_FILE=~/Toolchain-Ubuntu-mingw32.cmake ..
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(TOOLCHAIN_PREFIX i686-w64-mingw32)
+
+# cross compilers to use for C and C++
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
+
+# target environment on the build host system
+#   set 1st to dir with the cross compiler's C/C++ headers/libs
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# modify default behavior of FIND_XXX() commands to
+# search for headers/libs in the target environment and
+# search for programs in the build host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/cmake/Toolchain-Ubuntu-mingw32.cmake
+++ b/cmake/Toolchain-Ubuntu-mingw32.cmake
@@ -23,3 +23,6 @@ set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# add static libgcc libraries so there are no additional dependencies
+set(CMAKE_SHARED_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")

--- a/cmake/Toolchain-Ubuntu-mingw64.cmake
+++ b/cmake/Toolchain-Ubuntu-mingw64.cmake
@@ -1,0 +1,25 @@
+# Sample toolchain file for building for Windows from an Ubuntu Linux system.
+#
+# Typical usage:
+#    *) install cross compiler: `sudo apt-get install mingw-w64 g++-mingw-w64`
+#    *) cd build
+#    *) cmake -DCMAKE_TOOLCHAIN_FILE=~/Toolchain-Ubuntu-mingw64.cmake ..
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
+
+# cross compilers to use for C and C++
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_RC_COMPILER ${TOOLCHAIN_PREFIX}-windres)
+
+# target environment on the build host system
+#   set 1st to dir with the cross compiler's C/C++ headers/libs
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# modify default behavior of FIND_XXX() commands to
+# search for headers/libs in the target environment and
+# search for programs in the build host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/cmake/Toolchain-Ubuntu-mingw64.cmake
+++ b/cmake/Toolchain-Ubuntu-mingw64.cmake
@@ -23,3 +23,6 @@ set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# add static libgcc libraries so there are no additional dependencies
+set(CMAKE_SHARED_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")


### PR DESCRIPTION
The cmake files for crosscompiling under Linux for Windows are missing and the documentation has been outdated. 
I took an example file from freedv-gui and added it to codec2.