### PR TITLE
New function: freedv_set_fmin_fmax

### DIFF
--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -1372,6 +1372,25 @@ int freedv_get_bits_per_modem_frame       (struct freedv *f) {return f->bits_per
 int freedv_get_rx_status                  (struct freedv *f) {return f->rx_status;}
 void freedv_get_fsk_S_and_N               (struct freedv *f, float *S, float *N) { *S = f->fsk_S[0]; *N = f->fsk_N[0]; }
 
+
+/*---------------------------------------------------------------------------*\
+
+  FUNCTIONS...: freedv_set_fmin_fmax
+  AUTHOR......: Simon Lang - DJ2LS
+  DATE CREATED: 18 feb 2022
+
+  Set fmin / fmax for ofdm modem
+
+\*---------------------------------------------------------------------------*/
+void freedv_set_fmin_fmax(struct freedv *freedv, float val_fmin, float val_fmax) {
+    freedv->ofdm->fmin = val_fmin;
+    freedv->ofdm->fmax = val_fmax;
+}
+
+
+  
+
+
 int freedv_get_n_max_speech_samples(struct freedv *f) {
     /* When "passing through" demod samples to the speech output
        (e.g. no sync and squelch off) f->nin bounces around with

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -1378,13 +1378,18 @@ void freedv_get_fsk_S_and_N               (struct freedv *f, float *S, float *N)
   FUNCTIONS...: freedv_set_fmin_fmax
   AUTHOR......: Simon Lang - DJ2LS
   DATE CREATED: 18 feb 2022
-
-  Set fmin / fmax for ofdm modem
-
+  DEFAULT.....: fmin: -50.0Hz fmax: 50.0Hz
+  DESCRIPTION.:
+  
+  |<---fmin - | rx centre frequency | + fmax--->|
+  
+  Useful for handling frequency offsets, 
+  e.g. caused by an imprecise VFO, the trade off is more CPU power is required.  
+  
 \*---------------------------------------------------------------------------*/
-int freedv_set_fmin_fmax(struct freedv *freedv, float val_fmin, float val_fmax) {
+int freedv_set_tuning_range(struct freedv *freedv, float val_fmin, float val_fmax) {
 
-    if (is_ofdm_data_mode(freedv)) {
+    if (is_ofdm_mode(freedv)) {
         freedv->ofdm->fmin = val_fmin;
         freedv->ofdm->fmax = val_fmax;
         return 1;

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -1389,7 +1389,7 @@ void freedv_get_fsk_S_and_N               (struct freedv *f, float *S, float *N)
 \*---------------------------------------------------------------------------*/
 int freedv_set_tuning_range(struct freedv *freedv, float val_fmin, float val_fmax) {
 
-    if (is_ofdm_data_mode(freedv) && (strcmp(freedv->ofdm->data_mode, "burst"))) {
+    if (is_ofdm_data_mode(freedv) && (strcmp(freedv->ofdm->data_mode, "burst") == 0)) {
         freedv->ofdm->fmin = val_fmin;
         freedv->ofdm->fmax = val_fmax;
         return 1;

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -1389,7 +1389,7 @@ void freedv_get_fsk_S_and_N               (struct freedv *f, float *S, float *N)
 \*---------------------------------------------------------------------------*/
 int freedv_set_tuning_range(struct freedv *freedv, float val_fmin, float val_fmax) {
 
-    if (is_ofdm_mode(freedv)) {
+    if (is_ofdm_data_mode(freedv) && (strcmp(freedv->ofdm->data_mode, "burst"))) {
         freedv->ofdm->fmin = val_fmin;
         freedv->ofdm->fmax = val_fmax;
         return 1;

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -1375,7 +1375,7 @@ void freedv_get_fsk_S_and_N               (struct freedv *f, float *S, float *N)
 
 /*---------------------------------------------------------------------------*\
 
-  FUNCTIONS...: freedv_set_fmin_fmax
+  FUNCTIONS...: freedv_set_tuning_range
   AUTHOR......: Simon Lang - DJ2LS
   DATE CREATED: 18 feb 2022
   DEFAULT.....: fmin: -50.0Hz fmax: 50.0Hz

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -1382,13 +1382,16 @@ void freedv_get_fsk_S_and_N               (struct freedv *f, float *S, float *N)
   Set fmin / fmax for ofdm modem
 
 \*---------------------------------------------------------------------------*/
-void freedv_set_fmin_fmax(struct freedv *freedv, float val_fmin, float val_fmax) {
-    freedv->ofdm->fmin = val_fmin;
-    freedv->ofdm->fmax = val_fmax;
+int freedv_set_fmin_fmax(struct freedv *freedv, float val_fmin, float val_fmax) {
+
+    if (is_ofdm_data_mode(freedv)) {
+        freedv->ofdm->fmin = val_fmin;
+        freedv->ofdm->fmax = val_fmax;
+        return 1;
+    } else {
+        return 0;
+    }
 }
-
-
-  
 
 
 int freedv_get_n_max_speech_samples(struct freedv *f) {

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -240,6 +240,7 @@ void freedv_set_phase_est_bandwidth_mode(struct freedv *f, int val);
 void freedv_set_eq                      (struct freedv *f, int val);
 void freedv_set_frames_per_burst        (struct freedv *f, int framesperburst);
 void freedv_passthrough_gain            (struct freedv *f, float g);
+void freedv_set_fmin_fmax               (struct freedv *freedv, float val_fmin, float val_fmax);
 
 // Get parameters -------------------------------------------------------------------------
 

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -240,7 +240,7 @@ void freedv_set_phase_est_bandwidth_mode(struct freedv *f, int val);
 void freedv_set_eq                      (struct freedv *f, int val);
 void freedv_set_frames_per_burst        (struct freedv *f, int framesperburst);
 void freedv_passthrough_gain            (struct freedv *f, float g);
-int freedv_set_fmin_fmax                (struct freedv *freedv, float val_fmin, float val_fmax);
+int freedv_set_tuning_range             (struct freedv *freedv, float val_fmin, float val_fmax);
 
 // Get parameters -------------------------------------------------------------------------
 

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -240,7 +240,7 @@ void freedv_set_phase_est_bandwidth_mode(struct freedv *f, int val);
 void freedv_set_eq                      (struct freedv *f, int val);
 void freedv_set_frames_per_burst        (struct freedv *f, int framesperburst);
 void freedv_passthrough_gain            (struct freedv *f, float g);
-void freedv_set_fmin_fmax               (struct freedv *freedv, float val_fmin, float val_fmax);
+int freedv_set_fmin_fmax                (struct freedv *freedv, float val_fmin, float val_fmax);
 
 // Get parameters -------------------------------------------------------------------------
 

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -219,8 +219,8 @@ struct OFDM *ofdm_create(const struct OFDM_CONFIG *config) {
         ofdm->clip_en = false;
         ofdm->foff_limiter = false;
         ofdm->data_mode = "";
-        ofdm->fmin = -50.0;
-        ofdm->fmax = 50.0;
+        ofdm->fmin = -50.0;                       /* frequency minimum for ofdm acquisition range */
+        ofdm->fmax = 50.0;                        /* frequency maximum for ofdm acquisition range */
         memset(ofdm->tx_uw, 0, ofdm->nuwbits);
     } else {
         /* Use the users values */
@@ -254,8 +254,8 @@ struct OFDM *ofdm_create(const struct OFDM_CONFIG *config) {
         ofdm->clip_en = config->clip_en;
         memcpy(ofdm->tx_uw, config->tx_uw, ofdm->nuwbits);
         ofdm->data_mode = config->data_mode;
-        ofdm->fmin = config->fmin;
-        ofdm->fmax = config->fmax;
+        ofdm->fmin = config->fmin;              /* frequency minimum for ofdm acquisition range */
+        ofdm->fmax = config->fmax;              /* frequency maximum for ofdm acquisition range */
 
     }
 

--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -219,6 +219,8 @@ struct OFDM *ofdm_create(const struct OFDM_CONFIG *config) {
         ofdm->clip_en = false;
         ofdm->foff_limiter = false;
         ofdm->data_mode = "";
+        ofdm->fmin = -50.0;
+        ofdm->fmax = 50.0;
         memset(ofdm->tx_uw, 0, ofdm->nuwbits);
     } else {
         /* Use the users values */
@@ -252,6 +254,8 @@ struct OFDM *ofdm_create(const struct OFDM_CONFIG *config) {
         ofdm->clip_en = config->clip_en;
         memcpy(ofdm->tx_uw, config->tx_uw, ofdm->nuwbits);
         ofdm->data_mode = config->data_mode;
+        ofdm->fmin = config->fmin;
+        ofdm->fmax = config->fmax;
 
     }
 
@@ -297,6 +301,9 @@ struct OFDM *ofdm_create(const struct OFDM_CONFIG *config) {
     ofdm->config.clip_en = ofdm->clip_en;
     memcpy(ofdm->config.tx_uw, ofdm->tx_uw, ofdm->nuwbits);
     ofdm->config.data_mode = ofdm->data_mode;
+    ofdm->config.fmin = ofdm->fmin;
+    ofdm->config.fmax = ofdm->fmax;
+    
 
     /* Calculate sizes from config param */
 
@@ -421,6 +428,10 @@ struct OFDM *ofdm_create(const struct OFDM_CONFIG *config) {
     ofdm->nin = ofdm->samplesperframe;
     ofdm->mean_amp = 0.0f;
     ofdm->foff_metric = 0.0f;
+    
+    ofdm->fmin = -50.0f;
+    ofdm->fmax = 50.0f;
+    
     /*
      * Unique Word symbol placement.  Note we need to group the UW
      * bits so they fit into symbols.  The LDPC decoder works on
@@ -1158,9 +1169,9 @@ static void burst_acquisition_detector(struct OFDM *ofdm,
     
     float fmin, fmax, fstep;
     int tstep;
-    
+
     // initial search over coarse grid
-    tstep = 4; fstep = 5; fmin = -50.0; fmax = 50.0;
+    tstep = 4; fstep = 5; fmin = ofdm->fmin; fmax = ofdm->fmax;
     *timing_mx = est_timing_and_freq(ofdm, ct_est, foff_est,
                                  &rx[n], 2*ofdm->samplesperframe, 
                                  known_sequence, ofdm->samplesperframe,

--- a/src/ofdm_internal.h
+++ b/src/ofdm_internal.h
@@ -106,6 +106,8 @@ struct OFDM_CONFIG {
     bool  clip_en;
     char mode[16];        /* OFDM mode in string form */
     char *data_mode;
+    float fmin;
+    float fmax;
 };
 
 struct OFDM {
@@ -165,6 +167,9 @@ struct OFDM {
     float tx_nlower;      /* TX lowest carrier freq */
     float rx_nlower;      /* RX lowest carrier freq */
     float doc;            /* division of radian circle */
+    
+    float fmin;
+    float fmax;
 
     // Pointers
 


### PR DESCRIPTION
My first freedv api function :partying_face: 

### New api function for **setting fmin and fmax** for OFDM modems.

**Use-case:** FreeDATA / TNC environment, where adjusting or changing the frequency is not always an option, specially for remote operation. The default +/- 50Hz are also a little bit too sensitive, if a radio is not that precise regarding to its frequency. Playing with XIT and RIT of the radio would also be possible, but an increased range of decoding at cost of not too much increased CPU - why not, as if its making things easier. 


**Usage:**
`int freedv_set_tuning_range(struct freedv *freedv, float val_fmin, float val_fmax)`
returns 1 , if is ofdm mode
returns 0 , if not ofdm mode

**Example Python + ctypes with fmin and fmax +/- 150Hz :**
```
freedv_set_tuning_range.restype = c_int
freedv_set_tuning_range.argype = [c_void_p, c_float, c_float]
freedv_set_tuning_range(freedv, c_float(-150.0), c_float(150.0))
```