### PR TITLE
Remove duplicate includes.

### DIFF
--- a/src/freedv_data_rx.c
+++ b/src/freedv_data_rx.c
@@ -31,8 +31,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
-#include <stdlib.h>
-#include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
 


### PR DESCRIPTION
Resolves #314 by removing include definitions that were previously referenced.