### PR TITLE
Add override for objcopy to the toolchain file.

### DIFF
--- a/.github/workflows/cmake-sm1000.yml
+++ b/.github/workflows/cmake-sm1000.yml
@@ -23,11 +23,6 @@ jobs:
            sudo apt-get update
            sudo apt-get install octave octave-common octave-signal liboctave-dev gnuplot sox p7zip-full python3-numpy valgrind 
 
-    - name: Run ctests
-      working-directory: ${{github.workspace}}/build_linux
-      shell: bash
-      run: ctest --output-on-failure
-
     - name: Install ST Standard Peripheral Library (SM1000)
       working-directory: ${{github.workspace}}/stm32
       shell: bash

--- a/.github/workflows/cmake-sm1000.yml
+++ b/.github/workflows/cmake-sm1000.yml
@@ -1,0 +1,48 @@
+name: Build SM1000
+
+on: [pull_request]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Debug
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install packages
+      shell: bash
+      run: |
+           sudo apt-get update
+           sudo apt-get install octave octave-common octave-signal liboctave-dev gnuplot sox p7zip-full python3-numpy valgrind 
+
+    - name: Run ctests
+      working-directory: ${{github.workspace}}/build_linux
+      shell: bash
+      run: ctest --output-on-failure
+
+    - name: Install ST Standard Peripheral Library (SM1000)
+      working-directory: ${{github.workspace}}/stm32
+      shell: bash
+      run: git clone https://github.com/whimsicalraps/STM32F4xx_DSP_StdPeriph_Lib
+
+    - name: Install SM1000 prerequisites
+      working-directory: ${{github.workspace}}/stm32
+      shell: bash
+      run: sudo apt install gcc-arm-none-eabi
+
+    - name: Build SM1000
+      working-directory: ${{github.workspace}}/stm32
+      shell: bash
+      run: |
+           mkdir build_stm32
+           cd build_stm32
+           cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/STM32_Toolchain.cmake -DPERIPHLIBDIR=${{github.workspace}}/stm32/STM32F4xx_DSP_StdPeriph_Lib ..
+           make

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -63,3 +63,21 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest --output-on-failure
 
+    - name: Install ST Standard Peripheral Library (SM1000)
+      working-directory: ${{github.workspace}}/stm32
+      shell: bash
+      run: git clone https://github.com/whimsicalraps/STM32F4xx_DSP_StdPeriph_Lib
+
+    - name: Install SM1000 prerequisites
+      working-directory: ${{github.workspace}}/stm32
+      shell: bash
+      run: sudo apt install gcc-arm-none-eabi
+
+    - name: Build SM1000
+      working-directory: ${{github.workspace}}/stm32
+      shell: bash
+      run: |
+           mkdir build_stm32
+           cd build_stm32
+           cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/STM32_Toolchain.cmake -DPERIPHLIBDIR=${{github.workspace}}/stm32/STM32F4xx_DSP_StdPeriph_Lib ..
+           make

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,4 +1,4 @@
-name: CMake
+name: Build Codec2 for Linux
 
 on: [pull_request]
 
@@ -62,22 +62,3 @@ jobs:
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest --output-on-failure
-
-    - name: Install ST Standard Peripheral Library (SM1000)
-      working-directory: ${{github.workspace}}/stm32
-      shell: bash
-      run: git clone https://github.com/whimsicalraps/STM32F4xx_DSP_StdPeriph_Lib
-
-    - name: Install SM1000 prerequisites
-      working-directory: ${{github.workspace}}/stm32
-      shell: bash
-      run: sudo apt install gcc-arm-none-eabi
-
-    - name: Build SM1000
-      working-directory: ${{github.workspace}}/stm32
-      shell: bash
-      run: |
-           mkdir build_stm32
-           cd build_stm32
-           cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/STM32_Toolchain.cmake -DPERIPHLIBDIR=${{github.workspace}}/stm32/STM32F4xx_DSP_StdPeriph_Lib ..
-           make

--- a/stm32/cmake/STM32_Toolchain.cmake
+++ b/stm32/cmake/STM32_Toolchain.cmake
@@ -7,6 +7,7 @@ set(CMAKE_ASM_FLAGS "${CFLAGS} -x assembler-with-cpp")
 set(CMAKE_C_COMPILER ${ARM_GCC_BIN}arm-none-eabi-gcc)
 set(CMAKE_CXX_COMPILER ${ARM_GCC_BIN}arm-none-eabi-cpp)
 set(CMAKE_ASM ${ARM_GCC_BIN}arm-none-eabi-as)
+set(CMAKE_OBJCOPY ${ARM_GCC_BIN}arm-none-eabi-objcopy)
 set(CMAKE_C_FLAGS_INIT "-specs=nosys.specs" CACHE STRING "Required compiler init flags")
 set(CMAKE_CXX_FLAGS_INIT "-specs=nosys.specs" CACHE STRING "Required compiler init flags")
 ## https://stackoverflow.com/questions/10599038/can-i-skip-cmake-compiler-tests-or-avoid-error-unrecognized-option-rdynamic


### PR DESCRIPTION
1. Add building for the stm32 to the set of GitHub actions we run.
1. Per #322, CMake is improperly choosing the host version of `objdump` instead of the ARM version. This PR adds an override to the toolchain file to force CMake to choose the correct version.