### PR TITLE
FreeDV Tx real and complex ctests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -745,9 +745,16 @@ endif()
              COMMAND sh -c "dd bs=2560 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:ch> - - --No -20 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard"
              )
 
+    # exercises complex rx codepath, albiet with just real samples
     add_test(NAME test_freedv_api_700D_AWGN_BER_USECOMPLEX
              COMMAND sh -c "dd bs=2560 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:ch> - - --No -20 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard --usecomplex"
              )
+
+    add_test(NAME test_freedv_api_700D_real_comp
+             COMMAND sh -c "cd ${CMAKE_CURRENT_SOURCE_DIR}/unittest;
+                            PATH=$PATH:${CMAKE_CURRENT_BINARY_DIR}/demo:${CMAKE_CURRENT_BINARY_DIR}/unittest;
+                            ./check_real_comp.sh"
+            )
 
 if(LPCNET)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,12 +750,29 @@ endif()
              COMMAND sh -c "dd bs=2560 count=120 if=/dev/zero | $<TARGET_FILE:freedv_tx> 700D - - --testframes | $<TARGET_FILE:ch> - - --No -20 -f -10 | $<TARGET_FILE:freedv_rx> 700D - /dev/null --testframes --discard --usecomplex"
              )
 
+    # check real part of freedv_comptx() matches freedv_tx()
     add_test(NAME test_freedv_api_700D_real_comp
              COMMAND sh -c "cd ${CMAKE_CURRENT_SOURCE_DIR}/unittest;
                             PATH=$PATH:${CMAKE_CURRENT_BINARY_DIR}/demo:${CMAKE_CURRENT_BINARY_DIR}/unittest;
                             ./check_real_comp.sh"
             )
 
+    # exercises freedv_comptx()
+    add_test(NAME test_freedv_api_700D_comptx
+             COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/unittest;
+                            cat ${CMAKE_CURRENT_SOURCE_DIR}/raw/ve9qrp_10s.raw |
+                            ./freedv_700d_comptx |
+                            ./freedv_700d_comprx tx > /dev/null"
+             )
+           
+    # exercises freedv_comprx()
+    add_test(NAME test_freedv_api_700D_comprx
+             COMMAND sh -c "cd ${CMAKE_CURRENT_BINARY_DIR}/unittest;
+                            cat ${CMAKE_CURRENT_SOURCE_DIR}/raw/ve9qrp_10s.raw |
+                            ./freedv_700d_comptx |
+                            ./freedv_700d_comprx rx > /dev/null"
+             )
+           
 if(LPCNET)
 
     add_test(NAME test_freedv_api_2020_to_ofdm_demod

--- a/octave/tcohpsk.m
+++ b/octave/tcohpsk.m
@@ -281,7 +281,7 @@ for f=1:frames
 
   tx_bits_log = [tx_bits_log tx_bits];
 
-  [tx_symb tx_bits] = bits_to_qpsk_symbols(acohpsk, tx_bits, [], []);
+  [tx_symb tx_bits] = bits_to_qpsk_symbols(acohpsk, tx_bits, []);
   tx_symb_log = [tx_symb_log; tx_symb];
   
   tx_fdm_frame = [];

--- a/octave/tfdmdv.m
+++ b/octave/tfdmdv.m
@@ -101,7 +101,7 @@ for fr=1:frames
 
   [tx_bits f] = get_test_bits(f, Nc*Nb);
   tx_bits_log = [tx_bits_log tx_bits];
-  [tx_symbols f] = bits_to_psk(f, prev_tx_symbols, tx_bits, 'dqpsk');
+  [tx_symbols f] = bits_to_psk(f, prev_tx_symbols, tx_bits);
   prev_tx_symbols = tx_symbols;
   tx_symbols_log = [tx_symbols_log tx_symbols];
   [tx_baseband f] = tx_filter(f, tx_symbols);

--- a/octave/tofdm.m
+++ b/octave/tofdm.m
@@ -21,17 +21,8 @@ ldpc
 global passes = 0;
 global fails = 0;
 
-% attempt to start up CML, path will be different on your machine
-
-path_to_cml = '~/cml';
-addpath(strcat(path_to_cml, "/mex"), strcat(path_to_cml, "/mat"));
-cml_support = 0;
-if exist("Somap") == 0
-  printf("Can't find CML mex directory so we won't run those tests for now...\n");
-else
-  printf("OK found CML mex directory so will add those tests...\n");
-  cml_support = 1;
-end
+init_cml()
+cml_support = 1
 
 % ---------------------------------------------------------------------
 % Run Octave version 

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -122,3 +122,7 @@ add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/faster_fading_samples.float
   COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ./fading_files.sh ${CMAKE_CURRENT_BINARY_DIR}
 )
+
+add_executable(freedv_700d_comptx freedv_700d_comptx.c)
+target_link_libraries(freedv_700d_comptx m codec2)
+

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -126,3 +126,6 @@ add_custom_command(
 add_executable(freedv_700d_comptx freedv_700d_comptx.c)
 target_link_libraries(freedv_700d_comptx m codec2)
 
+add_executable(freedv_700d_comprx freedv_700d_comprx.c)
+target_link_libraries(freedv_700d_comprx m codec2)
+

--- a/unittest/check_real_comp.sh
+++ b/unittest/check_real_comp.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# check_real_comp.sh
+# Check the output of freedv_tx() and the real part of freedv_comptx() match,
+# as they use different code paths. Run from codec2/unittest, set path to
+# include codec2/build/misc and codec2/build/unittest
+
+set -x
+cat ../raw/ve9qrp_10s.raw | freedv_700d_tx > tx_700d.int16
+cat ../raw/ve9qrp_10s.raw | freedv_700d_comptx > tx_700d.iq16
+
+echo "tx_real=load_raw('tx_700d.int16'); tx_comp=load_raw('tx_700d.iq16'); \
+      tx_comp=tx_comp(1:2:end)+j*tx_comp(2:2:end); \
+      diff = sum(real(tx_comp)-tx_real); printf('diff: %f\n', diff); \
+      if diff < 1, quit(0), end; \
+      quit(1)" | octave-cli -p ../octave -qf

--- a/unittest/freedv_700d_comprx.c
+++ b/unittest/freedv_700d_comprx.c
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------*\
+
+  FILE........: freedv_700d_comprx.c
+  AUTHOR......: David Rowe
+  DATE CREATED: July 2022
+
+  Complex valued rx to support ctests.  Includes a few operations that will
+  only work if complex Tx and Rx signals are being handled correctly.
+ 
+\*---------------------------------------------------------------------------*/
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "freedv_api.h"
+#include "freedv_api_internal.h"
+#include "ofdm_internal.h"
+#include "codec2_cohpsk.h"
+#include "comp_prim.h"
+
+int main(int argc, char *argv[]) {
+
+    /* optional frequency offset - a good way to exercise complex valued signals */
+    float foff_hz = 0.0;
+    if (argc == 2) {
+        foff_hz = atof(argv[1]);
+        fprintf(stderr, "foff_hz: %f\n", foff_hz);
+    }
+    struct freedv *freedv;
+    freedv = freedv_open(FREEDV_MODE_700D);
+    assert(freedv != NULL);
+
+    /* note API functions to tell us how big our buffers need to be */
+    short speech_out[freedv_get_n_max_speech_samples(freedv)];
+    short demod_in[2*freedv_get_n_max_modem_samples(freedv)];
+    COMP  demod_in_comp[2*freedv_get_n_max_modem_samples(freedv)];
+    
+    size_t nin, nout;
+    nin = freedv_nin(freedv);
+
+    /* set up small freq offset */
+    COMP phase_ch; phase_ch.real = 1.0; phase_ch.imag = 0.0;
+
+    /* set complex sine wave interferer at -fc */
+    COMP interferer_phase = {1.0,0.0};
+    COMP interferer_freq;
+    interferer_freq.real = cos(2.0*M_PI*freedv->ofdm->tx_centre/FREEDV_FS_8000);
+    interferer_freq.imag = sin(2.0*M_PI*freedv->ofdm->tx_centre/FREEDV_FS_8000);
+    interferer_freq = cconj(interferer_freq);
+
+    /* log a file of demod input samples for plotting in Octave */
+    FILE *fdemod = fopen("demod.f32","wb"); assert(fdemod != NULL);
+
+    /* measure demod input power, interferer input power */
+    float power_d = 0.0; float power_interferer = 0.0; 
+    
+    while(fread(demod_in, sizeof(short), 2*nin, stdin) == 2*nin) {
+        for(int i=0; i<nin; i++) {
+            demod_in_comp[i].real = (float)demod_in[2*i];
+            demod_in_comp[i].imag = (float)demod_in[2*i+1];
+            //demod_in_comp[i].imag = 0;
+        }
+
+        /* So Tx is a complex OFDM signal centered at +fc.  A small
+           shift fd followed by Re{} will only work if Tx is complex.
+           If Tx is real, neg freq components at -fc+fd will be
+           aliased on top of fc+fd wanted signal by Re{} operation.
+           This can be tested by setting demod_in_comp[i].imag = 0
+           above */
+        fdmdv_freq_shift_coh(demod_in_comp, demod_in_comp, foff_hz, FREEDV_FS_8000, &phase_ch, nin);
+        for(int i=0; i<nin; i++)
+            demod_in_comp[i].imag = 0.0;
+        
+        /* a complex sinewave (carrier) at -fc will only be ignored if
+           Rx is treating signal as complex, otherwise if real a +fc
+           alias will appear in the middle of our wanted signal at
+           +fc, this can be tested by setting demod_in_comp[i].imag =
+           0 below */
+        for(int i=0; i<nin; i++) {
+            COMP a = fcmult(1E4,interferer_phase);
+            interferer_phase = cmult(interferer_phase, interferer_freq);
+            power_interferer += a.real*a.real + a.imag*a.imag;
+            COMP d = demod_in_comp[i];
+            power_d += d.real*d.real + d.imag*d.imag;
+            demod_in_comp[i] = cadd(d,a);
+            demod_in_comp[i].imag = 0;
+        }
+
+        /* useful to take a look at this with Octave */
+        fwrite(demod_in_comp, sizeof(COMP), nin, fdemod);
+        
+        nout = freedv_comprx(freedv, speech_out, demod_in_comp);
+        nin = freedv_nin(freedv); /* call me on every loop! */
+        fwrite(speech_out, sizeof(short), nout, stdout);
+        int sync; float snr_est;
+        freedv_get_modem_stats(freedv, &sync, &snr_est);
+        fprintf(stderr, "sync: %d  snr_est: %f\n", sync, snr_est);
+    }
+
+    fclose(fdemod);
+    freedv_close(freedv);
+
+    fprintf(stderr, "Demod/Interferer power ratio: %3.2f dB\n", 10*log10(power_d/power_interferer));
+    return 0;
+}

--- a/unittest/freedv_700d_comprx.c
+++ b/unittest/freedv_700d_comprx.c
@@ -58,7 +58,8 @@ int main(int argc, char *argv[]) {
 
     /* measure demod input power, interferer input power */
     float power_d = 0.0; float power_interferer = 0.0; 
-    
+
+    int frames = 0, sum_sync = 0, frames_snr = 0; float sum_snr = 0.0;
     size_t nin, nout;
     nin = freedv_nin(freedv);
 
@@ -107,6 +108,7 @@ int main(int argc, char *argv[]) {
         int sync; float snr_est;
         freedv_get_modem_stats(freedv, &sync, &snr_est);
         fprintf(stderr, "sync: %d  snr_est: %f\n", sync, snr_est);
+        frames++; sum_sync += sync; if (sync) { sum_snr += snr_est; frames_snr++; }
     }
 
     fclose(fdemod);
@@ -114,5 +116,11 @@ int main(int argc, char *argv[]) {
 
     if (test_num == 2)
         fprintf(stderr, "Demod/Interferer power ratio: %3.2f dB\n", 10*log10(power_d/power_interferer));
-    return 0;
+    float snr_av = sum_snr/frames_snr;
+    fprintf(stderr, "frames: %d sum_sync: %d snr_av: %3.2f dB\n", frames, sum_sync, snr_av);
+
+    if (snr_av > 10.0)
+        return 0;
+    else
+        return 1;
 }

--- a/unittest/freedv_700d_comptx.c
+++ b/unittest/freedv_700d_comptx.c
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------*\
+
+  freedv_comptx.c
+
+  Complex valued Tx to support ctests.
+
+\*---------------------------------------------------------------------------*/
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "freedv_api.h"
+
+int main(int argc, char *argv[]) {
+    struct freedv            *freedv;
+
+    freedv = freedv_open(FREEDV_MODE_700D);
+    assert(freedv != NULL);
+
+    /* handy functions to set buffer sizes */
+    int n_speech_samples = freedv_get_n_speech_samples(freedv);
+    short speech_in[n_speech_samples];
+    int n_nom_modem_samples = freedv_get_n_nom_modem_samples(freedv);
+    COMP mod_out[n_nom_modem_samples];
+    short mod_out_short[2*n_nom_modem_samples];
+
+    /* OK main loop  --------------------------------------- */
+
+    while(fread(speech_in, sizeof(short), n_speech_samples, stdin) == n_speech_samples) {
+        freedv_comptx(freedv, mod_out, speech_in);
+        for(int i=0; i<n_nom_modem_samples; i++) {
+            mod_out_short[2*i] = mod_out[i].real;
+            mod_out_short[2*i+1] = mod_out[i].imag;
+        }
+        fwrite(mod_out_short, sizeof(short), 2*n_nom_modem_samples, stdout);
+    }
+
+    freedv_close(freedv);
+
+    return 0;
+}


### PR DESCRIPTION
Some new ctests:
1. Compare `freedv_tx()` and `real(freedv_comptx())` outputs, to support #326 where they have different code paths. :heavy_check_mark: 
1. Test for `freedv_comptx()` and `freedv_comprx()` that exercises complex valued signals. Tests fail if signals are real valued :heavy_check_mark: 