### PR TITLE
Increment version to 1.0.4.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ set(CODEC2_VERSION_MAJOR 1)
 set(CODEC2_VERSION_MINOR 0)
 # Set to patch level if needed, otherwise leave FALSE.
 # Must be positive (non-zero) if set, since 0 == FALSE in CMake.
-set(CODEC2_VERSION_PATCH 3)
+set(CODEC2_VERSION_PATCH 4)
 set(CODEC2_VERSION "${CODEC2_VERSION_MAJOR}.${CODEC2_VERSION_MINOR}")
 # Patch level version bumps should not change API/ABI.
 set(SOVERSION "${CODEC2_VERSION_MAJOR}.${CODEC2_VERSION_MINOR}")


### PR DESCRIPTION
Per https://github.com/drowe67/freedv-gui/issues/255, release 1.0.4 so that people have access to 2020B mode.