### PR TITLE
remove 2020x index opt support that broke FreeDV API

### DIFF
--- a/src/freedv_2020.c
+++ b/src/freedv_2020.c
@@ -36,7 +36,7 @@
 extern char *ofdm_statemode[];
 
 #ifdef __LPCNET__
-void freedv_2020x_open(struct freedv *f, int vq_type) {
+void freedv_2020x_open(struct freedv *f) {
     f->speech_sample_rate = FREEDV_FS_16000;
     f->snr_squelch_thresh = 4.0;
     f->squelch_en = 0;
@@ -60,13 +60,16 @@ void freedv_2020x_open(struct freedv *f, int vq_type) {
 
     ldpc_codes_setup(f->ldpc, f->ofdm->codename);
     int data_bits_per_frame;
+    int vq_type;
     switch (f->mode) {
     case FREEDV_MODE_2020:
         data_bits_per_frame = 312;
+        vq_type = 1;    /* vanilla VQ */
         break;
     case FREEDV_MODE_2020B:
         f->ldpc->protection_mode = LDPC_PROT_2020B;
         data_bits_per_frame = 156;
+        vq_type = 2;    /* index optimised VQ for increased robustness to single bit errors */
         break;
     default:
         assert(0);

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -4,12 +4,13 @@
   AUTHOR......: David Rowe
   DATE CREATED: August 2014
 
-  Library of API functions that implement FreeDV "modes", useful for
+  Library of API functions that implement the FreeDV API, useful for
   embedding FreeDV in other programs.  Please see:
 
   1. README_freedv.md
-  2. Notes function use in freedv_api.c
-  3. The sample freedv_tx.c and freedv_rx.c programs
+  2. Notes on function use in this file
+  3. Simple demo programs in the "demo" directory
+  4. The full featured command line freedv_tx.c and freedv_rx.c programs
 
 \*---------------------------------------------------------------------------*/
 
@@ -110,17 +111,6 @@ char *rx_sync_flags_to_text[] = {
 struct freedv *freedv_open(int mode) {
     // defaults for those modes that support the use of adv
     struct freedv_advanced adv = {0,2,100,8000,1000,200, "H_256_512_4"};
-#ifdef __LPCNET__
-    // set up default Vector Quantisers (VQs) for LPCNet */
-    switch (mode) {
-    case FREEDV_MODE_2020:
-        adv.lpcnet_vq_type = 1;    /* vanilla VQ */
-        break;
-    case FREEDV_MODE_2020B:
-        adv.lpcnet_vq_type = 2;    /* index optimised VQ for theorectical robustness to single bit errors */
-        break;
-    }
-#endif        
     return freedv_open_advanced(mode, &adv);
 }
 
@@ -155,10 +145,9 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
     if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, mode)) freedv_ofdm_voice_open(f, "700D");
     if (FDV_MODE_ACTIVE( FREEDV_MODE_700E, mode)) freedv_ofdm_voice_open(f, "700E");
 #ifdef __LPCNET__
-    if (FDV_MODE_ACTIVE( FREEDV_MODE_2020, mode)  ||
-        FDV_MODE_ACTIVE( FREEDV_MODE_2020B, mode))
-        freedv_2020x_open(f, adv->lpcnet_vq_type);
-#endif
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_2020, mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2020B, mode))
+        freedv_2020x_open(f);
+#endif        
     if (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, mode)) freedv_2400a_open(f);
     if (FDV_MODE_ACTIVE( FREEDV_MODE_2400B, mode)) freedv_2400b_open(f);
     if (FDV_MODE_ACTIVE( FREEDV_MODE_800XA, mode)) freedv_800xa_open(f);

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -4,7 +4,7 @@
   AUTHOR......: David Rowe
   DATE CREATED: August 2014
 
-  Library of API functions that implement FreeDV "modes", useful for
+  Library of API functions that implement the FreeDV API, useful for
   embedding FreeDV in other programs.  Please see:
 
   1. README_freedv.md
@@ -137,7 +137,7 @@ struct freedv;
 
 // Some modes allow extra configuration parameters
 struct freedv_advanced {
-    int lpcnet_vq_type;                      // see lpcnet_freedv.h
+    int interleave_frames;                   // now unused but remains to prevent breaking API for legacy apps
 
     // parameters for FREEDV_MODE_FSK_LDPC
     int M;                                   // 2 or 4 FSK

--- a/src/freedv_api_internal.h
+++ b/src/freedv_api_internal.h
@@ -197,7 +197,7 @@ struct freedv {
 void freedv_1600_open(struct freedv *f);
 void freedv_700c_open(struct freedv *f);
 void freedv_ofdm_voice_open(struct freedv *f, char *mode);
-void freedv_2020x_open(struct freedv *f, int vq_type);
+void freedv_2020x_open(struct freedv *f);
 void freedv_2400a_open(struct freedv *f);
 void freedv_2400b_open(struct freedv *f);
 void freedv_800xa_open(struct freedv *f);

--- a/src/freedv_rx.c
+++ b/src/freedv_rx.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[]) {
     float                      snr_est;
     float                      clock_offset;
     int                        use_testframes, verbose, discard, use_complex, use_dpsk, use_reliabletext;
-    int                        use_squelch, vq_type;
+    int                        use_squelch;
     float                      squelch = 0;
     struct freedv             *freedv;
     int                        use_passthroughgain;
@@ -81,8 +81,6 @@ int main(int argc, char *argv[]) {
                 "\n"
                 "  --discard               Reset BER stats on loss of sync, helps us get sensible BER results\n"
                 "  --dpsk                  Use differential PSK rather than coherent PSK\n"
-                "  --indopt       0|1      Choose index optimised VQ for 2020/2020B, no effect other modes\n"
-                "                          default for 2020/2020B 0/1/1 (off/on/on)\n"
                 "  --reliabletext txt      Send 'txt' using reliable text protocol\n"
                 "  --txtrx        filename Store reliable text output to filename\n"
                 "  --squelch      leveldB  Set squelch level\n"
@@ -96,7 +94,7 @@ int main(int argc, char *argv[]) {
     }
 
     use_testframes = verbose = discard = use_complex = use_dpsk = use_squelch = 0; use_reliabletext = 0;
-    vq_type = -1; use_passthroughgain = 0;
+    use_passthroughgain = 0;
     
     int o = 0;
     int opt_idx = 0;
@@ -112,12 +110,11 @@ int main(int argc, char *argv[]) {
             {"usecomplex",      no_argument,        0, 'c'},
             {"verbose1",        no_argument,        0, 'v'},
             {"vv",              no_argument,        0, 'w'},
-            {"indopt",          required_argument,  0, 'n'},
             {"passthroughgain", required_argument,  0, 'p'},
             {0, 0, 0, 0}
         };
 
-        o = getopt_long(argc,argv,"idhr:s:x:tcvwn:p:",long_opts,&opt_idx);
+        o = getopt_long(argc,argv,"idhr:s:x:tcvwp:",long_opts,&opt_idx);
 
         switch(o) {
         case 'i':
@@ -128,12 +125,6 @@ int main(int argc, char *argv[]) {
             break;
         case 'd':
             use_dpsk = 1;
-            break;
-        case 'n':
-            if (atoi(optarg) == 0)
-                vq_type = 1;
-            else
-                vq_type = 2;
             break;
 	case 'p':
 	    use_passthroughgain = 1;
@@ -203,14 +194,7 @@ int main(int argc, char *argv[]) {
 	exit(1);
     }
 
-    if (vq_type == -1)
-        freedv = freedv_open(mode);
-    else {
-        // 2020x: specify VQ type
-        struct freedv_advanced adv;
-        adv.lpcnet_vq_type = vq_type;
-        freedv = freedv_open_advanced(mode, &adv);
-    }
+    freedv = freedv_open(mode);
     assert(freedv != NULL);
 
     /* set up a few options, calling these is optional -------------------------*/

--- a/src/freedv_tx.c
+++ b/src/freedv_tx.c
@@ -61,7 +61,6 @@ int main(int argc, char *argv[]) {
     struct freedv            *freedv;
     int                       mode;
     int                       use_testframes, use_clip, use_txbpf, use_dpsk, use_reliabletext;
-    int                       vq_type;
     char                     *callsign = "";
     reliable_text_t           reliable_text_obj;
     char f2020[80] = {0};
@@ -76,8 +75,6 @@ int main(int argc, char *argv[]) {
                 "  --clip         0|1  Clipping (compression) of modem output samples for reduced PAPR\n"
                 "                      and higher average power\n"
                 "  --dpsk              Use differential PSK rather than coherent PSK\n"
-                "  --indopt       0|1  Choose index optimised VQ for 2020/2020B, no effect other modes\n"
-                "                      default for 2020/2020B 0/1/1 (off/on/on)\n"
                 "  --reliabletext txt  Send 'txt' using reliable text protocol\n"
                 "  --testframes        Send testframe instead of coded speech. Number of testsframes depends on\n"
                 "                      length of speech input file\n"
@@ -88,7 +85,6 @@ int main(int argc, char *argv[]) {
     }
 
     use_testframes = 0; use_clip = 0; use_txbpf = 1; use_dpsk = 0; use_reliabletext = 0;
-    vq_type = -1;
 
     int o = 0;
     int opt_idx = 0;
@@ -100,11 +96,10 @@ int main(int argc, char *argv[]) {
             {"reliabletext",   required_argument,  0, 'r'},
             {"testframes",     no_argument,        0, 't'},
             {"txbpf",          required_argument,  0, 'b'},
-            {"indopt",         required_argument,  0, 'n'},
             {0, 0, 0, 0}
         };
 
-        o = getopt_long(argc,argv,"l:dhr:tb:n:",long_opts,&opt_idx);
+        o = getopt_long(argc,argv,"l:dhr:tb:",long_opts,&opt_idx);
 
         switch(o) {
         case 'b':
@@ -115,12 +110,6 @@ int main(int argc, char *argv[]) {
             break;
         case 'l':
             use_clip = atoi(optarg);
-            break;
-        case 'n':
-            if (atoi(optarg) == 0)
-                vq_type = 1;
-            else
-                vq_type = 2;
             break;
         case 'r':
             use_reliabletext = 1;
@@ -171,15 +160,7 @@ int main(int argc, char *argv[]) {
         exit(1);
     }
 
-    if (vq_type == -1)
-        freedv = freedv_open(mode);
-    else {
-        // 2020x: specify VQ type
-        struct freedv_advanced adv;
-        adv.lpcnet_vq_type = vq_type;
-        freedv = freedv_open_advanced(mode, &adv);
-    }
-
+    freedv = freedv_open(mode);
     assert(freedv != NULL);
 
     /* these are all optional ------------------ */


### PR DESCRIPTION
1. Remove experimental adv.lpcnet_vq_type used for 2020x index opt experiments.
2. Make FreeDV API compatible with earlier versions to support 3rd party applications.
3. Hard coded`vq_type` for 2020 and 2020B, rather tan making it an API selectable option.
4. Support a codec2 1.0.4 release candidate 2 tag/release, to allow an up to date freedv-gui version to be released.

Note that given 2020C is a work in progress https://github.com/drowe67/codec2/pull/319, we are not sure if 2020B will continue to be supported, so it should still be considered experimental.