### PR TITLE
update cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/.git)
     find_package(Git QUIET)
     if(Git_FOUND)
         execute_process(
-            COMMAND "${GIT_EXECUTABLE}" describe --always HEAD
+            COMMAND "${GIT_EXECUTABLE}" git rev-parse --short HEAD
             WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
             RESULT_VARIABLE res
             OUTPUT_VARIABLE FREEDV_HASH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,19 +5,13 @@
 # Please report questions, comments, problems, or patches to the freetel
 # mailing list: https://lists.sourceforge.net/lists/listinfo/freetel-codec2
 #
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
-
-project(codec2)
-
-cmake_minimum_required(VERSION 3.0)
-
-# Set policies here, probably should move to cmake dir.
-if(POLICY CMP0075)
-    cmake_policy(SET CMP0075 NEW)
-endif()
-if(POLICY CMP0079)
-    cmake_policy(SET CMP0079 NEW)
-endif()
+cmake_minimum_required(VERSION 3.13)
+project(CODEC2
+  VERSION 1.0.5
+  DESCRIPTION "Next-Generation Digital Voice for Two-Way Radio"
+  HOMEPAGE_URL "https://www.rowetel.com/codec2.html"
+  LANGUAGES C
+  )
 
 include(GNUInstallDirs)
 mark_as_advanced(CLEAR
@@ -39,23 +33,6 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
    "separate build directory and run cmake from there.")
 endif("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
 
-#
-# Set project version information. This should probably be done via external
-# file at some point.
-#
-set(CODEC2_VERSION_MAJOR 1)
-set(CODEC2_VERSION_MINOR 0)
-# Set to patch level if needed, otherwise leave FALSE.
-# Must be positive (non-zero) if set, since 0 == FALSE in CMake.
-set(CODEC2_VERSION_PATCH 5)
-set(CODEC2_VERSION "${CODEC2_VERSION_MAJOR}.${CODEC2_VERSION_MINOR}")
-# Patch level version bumps should not change API/ABI.
-set(SOVERSION "${CODEC2_VERSION_MAJOR}.${CODEC2_VERSION_MINOR}")
-if(CODEC2_VERSION_PATCH)
-    set(CODEC2_VERSION "${CODEC2_VERSION}.${CODEC2_VERSION_PATCH}")
-endif()
-message(STATUS "codec2 version: ${CODEC2_VERSION}")
-
 # Set default build type
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug")
@@ -65,6 +42,7 @@ endif()
 if(BUILD_OSX_UNIVERSAL)
 set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
 endif(BUILD_OSX_UNIVERSAL)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
 
 #
 # Find the git hash if this is a working copy.
@@ -190,10 +168,6 @@ if (_GNU_SOURCE)
     add_definitions(-D_GNU_SOURCE=1)
 endif()
 
-if(UNIX)
-    set(CMAKE_REQUIRED_LIBRARIES m)
-endif()
-
 check_symbol_exists(floor  math.h   HAVE_FLOOR)
 check_symbol_exists(ceil   math.h   HAVE_CEIL)
 check_symbol_exists(pow    math.h   HAVE_POW)
@@ -288,11 +262,7 @@ else()
 endif()
 
 # Return the date (yyyy-mm-dd)
-macro(DATE RESULT)
-  execute_process(COMMAND "date" "+%Y%m%d" OUTPUT_VARIABLE ${RESULT})
-endmacro()
-DATE(DATE_RESULT)
-string(REGEX REPLACE "\n$" "" DATE_RESULT "${DATE_RESULT}")
+string(TIMESTAMP DATE_RESULT "%Y-%m-%d" UTC)
 message(STATUS "Compilation date = XX${DATE_RESULT}XX")
 
 set(CPACK_PACKAGE_VERSION_PATCH "${CPACK_PACKAGE_VERSION_PATCH}-${DATE_RESULT}-${FREEDV_HASH}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,17 +48,17 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment ver
 # Find the git hash if this is a working copy.
 #
 if(EXISTS ${CMAKE_SOURCE_DIR}/.git)
-    find_package(Git QUIET)
+    find_package(Git)
     if(Git_FOUND)
         execute_process(
-            COMMAND "${GIT_EXECUTABLE}" git rev-parse --short HEAD
+            COMMAND "${GIT_EXECUTABLE}" rev-parse --short HEAD
             WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
             RESULT_VARIABLE res
-            OUTPUT_VARIABLE FREEDV_HASH
+            OUTPUT_VARIABLE CODEC2_HASH
             ERROR_QUIET
             OUTPUT_STRIP_TRAILING_WHITESPACE)
-        message(STATUS "freedv-gui current git hash: ${FREEDV_HASH}")
-        add_definitions(-DGIT_HASH="${FREEDV_HASH}")
+        message(STATUS "Codec2 current git hash: ${CODEC2_HASH}")
+        add_definitions(-DGIT_HASH="${CODEC2_HASH}")
     else()
         message(WARNING "Git not found. Can not determine current commit hash.")
         add_definitions(-DGIT_HASH="Unknown")
@@ -103,27 +103,6 @@ set(CMAKE_C_FLAGS_RELEASE "-O3")
 if(MINGW)
     message(STATUS "System is MinGW.")
 endif(MINGW)
-
-
-#
-# Find the git hash if this is a working copy.
-#
-if(EXISTS ${CMAKE_SOURCE_DIR}/.git)
-    find_package(Git)
-    if(Git_FOUND)
-        execute_process(
-            COMMAND "${GIT_EXECUTABLE}" describe --always HEAD
-            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-            RESULT_VARIABLE res
-            OUTPUT_VARIABLE CODEC2_HASH
-            ERROR_QUIET
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
-        message(STATUS "Codec2 current git hash: ${CODEC2_HASH}")
-    else()
-        message(WARNING "Git not found. Can not determine current commit hash.")
-    endif()
-endif()
-
 
 #
 # Default options
@@ -265,7 +244,7 @@ endif()
 string(TIMESTAMP DATE_RESULT "%Y-%m-%d" UTC)
 message(STATUS "Compilation date = XX${DATE_RESULT}XX")
 
-set(CPACK_PACKAGE_VERSION_PATCH "${CPACK_PACKAGE_VERSION_PATCH}-${DATE_RESULT}-${FREEDV_HASH}")
+set(CPACK_PACKAGE_VERSION_PATCH "${CPACK_PACKAGE_VERSION_PATCH}-${DATE_RESULT}-${CODEC2_HASH}")
 
 if(WIN32)
     #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,7 +81,7 @@ else(CMAKE_CROSSCOMPILING)
 # Build code generator binaries. These do not get installed.
     # generate_codebook
     add_executable(generate_codebook generate_codebook.c)
-    target_link_libraries(generate_codebook m ${CMAKE_REQUIRED_LIBRARIES})
+    target_link_libraries(generate_codebook m)
     # Make native builds available for cross-compiling.
     export(TARGETS generate_codebook
         FILE ${CMAKE_BINARY_DIR}/ImportExecutables.cmake)
@@ -238,12 +238,16 @@ set(CODEC2_PUBLIC_HEADERS
 #
 # Setup the codec2 library
 #
+# Patch level version bumps should not change API/ABI.
+set(SOVERSION "${CODEC2_VERSION_MAJOR}.${CODEC2_VERSION_MINOR}")
+message(STATUS "codec2 version: ${CODEC2_VERSION}")
 add_library(codec2 ${CODEC2_SRCS})
 if(UNIX)
-    target_link_libraries(codec2 m)
+    target_link_libraries(codec2 PUBLIC m)
 endif(UNIX)
 if(LPCNET AND lpcnetfreedv_FOUND)
-    target_link_libraries(codec2 lpcnetfreedv)
+    target_link_libraries(codec2 PRIVATE lpcnetfreedv)
+    list(APPEND CODEC2_PUBLIC_HEADERS ${CMAKE_SOURCE_DIR}/lpcnet/src/lpcnet_freedv.h)
 endif()
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(codec2 PROPERTIES
@@ -269,70 +273,70 @@ export(TARGETS codec2
 )
 
 add_executable(c2enc c2enc.c)
-target_link_libraries(c2enc ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(c2enc codec2)
 
 add_executable(c2dec c2dec.c)
-target_link_libraries(c2dec ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(c2dec codec2)
 
 add_executable(c2sim c2sim.c sd.c)
-target_link_libraries(c2sim ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(c2sim codec2)
 
 add_executable(fdmdv_get_test_bits fdmdv_get_test_bits.c fdmdv.c kiss_fft.c codec2_fft.c kiss_fftr.c)
-target_link_libraries(fdmdv_get_test_bits m ${CMAKE_REQUIRED_LIBRARIES})
+target_link_libraries(fdmdv_get_test_bits m)
 
 add_executable(fdmdv_mod fdmdv_mod.c fdmdv.c kiss_fft.c codec2_fft.c kiss_fftr.c)
-target_link_libraries(fdmdv_mod m ${CMAKE_REQUIRED_LIBRARIES})
+target_link_libraries(fdmdv_mod m)
 
 add_executable(fdmdv_demod fdmdv_demod.c fdmdv.c kiss_fft.c octave.c modem_stats.c codec2_fft.c kiss_fftr.c)
-target_link_libraries(fdmdv_demod m ${CMAKE_REQUIRED_LIBRARIES})
+target_link_libraries(fdmdv_demod m)
 
 add_executable(fdmdv_put_test_bits fdmdv_put_test_bits.c fdmdv.c kiss_fft.c codec2_fft.c kiss_fftr.c)
-target_link_libraries(fdmdv_put_test_bits m ${CMAKE_REQUIRED_LIBRARIES})
+target_link_libraries(fdmdv_put_test_bits m)
 
 add_executable(fdmdv_channel fdmdv_channel.c)
-target_link_libraries(fdmdv_channel ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(fdmdv_channel codec2)
 
 add_executable(insert_errors insert_errors.c)
-target_link_libraries(insert_errors ${CMAKE_REQUIRED_LIBRARIES})
+target_link_libraries(insert_errors)
 
 add_executable(freedv_tx freedv_tx.c)
-target_link_libraries(freedv_tx ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(freedv_tx codec2)
 
 add_executable(freedv_rx freedv_rx.c)
-target_link_libraries(freedv_rx ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(freedv_rx codec2)
 
 add_executable(freedv_data_raw_tx freedv_data_raw_tx.c)
-target_link_libraries(freedv_data_raw_tx ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(freedv_data_raw_tx codec2)
 
 add_executable(freedv_data_raw_rx freedv_data_raw_rx.c octave.c)
-target_link_libraries(freedv_data_raw_rx ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(freedv_data_raw_rx codec2)
 
 add_executable(freedv_data_tx freedv_data_tx.c)
-target_link_libraries(freedv_data_tx ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(freedv_data_tx codec2)
 
 add_executable(freedv_data_rx freedv_data_rx.c)
-target_link_libraries(freedv_data_rx ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(freedv_data_rx codec2)
 
 add_executable(freedv_mixed_tx freedv_mixed_tx.c)
-target_link_libraries(freedv_mixed_tx ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(freedv_mixed_tx codec2)
 
 add_executable(freedv_mixed_rx freedv_mixed_rx.c)
-target_link_libraries(freedv_mixed_rx ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(freedv_mixed_rx codec2)
 
 add_executable(fsk_mod fsk_mod.c)
-target_link_libraries(fsk_mod ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(fsk_mod codec2)
 
 add_executable(fsk_mod_ext_vco fsk_mod_ext_vco.c)
-target_link_libraries(fsk_mod_ext_vco m ${CMAKE_REQUIRED_LIBRARIES})
+target_link_libraries(fsk_mod_ext_vco m)
 
 add_executable(fsk_demod fsk_demod.c modem_probe.c octave.c)
-target_link_libraries(fsk_demod ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(fsk_demod codec2)
 
 add_executable(fsk_get_test_bits fsk_get_test_bits.c)
 target_link_libraries(fsk_get_test_bits)
 
 add_executable(fsk_put_test_bits fsk_put_test_bits.c)
-target_link_libraries(fsk_put_test_bits ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(fsk_put_test_bits codec2)
 
 add_executable(framer framer.c)
 target_link_libraries(framer)
@@ -341,46 +345,46 @@ add_executable(deframer deframer.c)
 target_link_libraries(deframer)
 
 add_executable(fm_demod fm_demod.c fm.c)
-target_link_libraries(fm_demod m ${CMAKE_REQUIRED_LIBRARIES})
+target_link_libraries(fm_demod m)
 
 add_executable(cohpsk_mod cohpsk_mod.c)
-target_link_libraries(cohpsk_mod ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(cohpsk_mod codec2)
 
 add_executable(ofdm_get_test_bits ofdm_get_test_bits.c)
-target_link_libraries(ofdm_get_test_bits ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(ofdm_get_test_bits codec2)
 
 add_executable(ofdm_put_test_bits ofdm_put_test_bits.c)
-target_link_libraries(ofdm_put_test_bits ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(ofdm_put_test_bits codec2)
 
 add_executable(ofdm_mod ofdm_mod.c)
-target_link_libraries(ofdm_mod ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(ofdm_mod codec2)
 
 add_executable(ofdm_demod ofdm_demod.c octave.c)
-target_link_libraries(ofdm_demod ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(ofdm_demod codec2)
 
 add_executable(fmfsk_mod fmfsk_mod.c)
-target_link_libraries(fmfsk_mod ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(fmfsk_mod codec2)
 
 add_executable(fmfsk_demod fmfsk_demod.c modem_probe.c octave.c)
-target_link_libraries(fmfsk_demod ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(fmfsk_demod codec2)
 
 add_executable(vhf_deframe_c2 vhf_deframe_c2.c)
-target_link_libraries(vhf_deframe_c2  ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(vhf_deframe_c2  codec2)
 
 add_executable(vhf_frame_c2 vhf_frame_c2.c)
-target_link_libraries(vhf_frame_c2  ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(vhf_frame_c2  codec2)
 
 add_executable(cohpsk_demod cohpsk_demod.c octave.c)
-target_link_libraries(cohpsk_demod ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(cohpsk_demod codec2)
 
 add_executable(cohpsk_get_test_bits cohpsk_get_test_bits.c)
-target_link_libraries(cohpsk_get_test_bits ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(cohpsk_get_test_bits codec2)
 
 add_executable(cohpsk_put_test_bits cohpsk_put_test_bits.c octave.c)
-target_link_libraries(cohpsk_put_test_bits ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(cohpsk_put_test_bits codec2)
 
 add_executable(ch ch.c)
-target_link_libraries(ch ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(ch codec2)
 
 add_executable(tollr tollr.c)
 
@@ -388,10 +392,10 @@ add_executable(ldpc_noise ldpc_noise.c)
 target_link_libraries(ldpc_noise m)
 
 add_executable(ldpc_enc ldpc_enc.c)
-target_link_libraries(ldpc_enc ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(ldpc_enc codec2)
 
 add_executable(ldpc_dec ldpc_dec.c)
-target_link_libraries(ldpc_dec ${CMAKE_REQUIRED_LIBRARIES} codec2)
+target_link_libraries(ldpc_dec codec2)
 
 install(TARGETS codec2 EXPORT codec2-config
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib


### PR DESCRIPTION
Some minor refactoring of Codec2 build to better use CMake
features to improve readability ans maintainability.

About this update cmake patch to codec2:

- Follow the convention of cmake_minimum_required() being the first CMake command.
  (Moved CMAKE_OSX_DEPLOYMENT_TARGET definition down next to another OSX setting.)

- Update cmake_minimum_required to 3.13.
  (Since that is where POLICY CMP0079 is introduced. We want to follow NEW usage,
   so that seems best. The cmake_policy() handling can be removed.)

- Use (new since CMake 3.0) project() features.
  This is the best single-point definition of project version information.
  (This handles the CODEC2_VERSION* variables for us, so the other definitions
   can be removed.)

- Better DATE_RESULT setting.
  Using CMake's string(TIMESTAMP... function does this in 1 line rather than 5.
  Also, CMake honors the SOURCE_DATE_EPOCH environment variable needed to support
  reproducible builds.
  https://reproducible-builds.org/specs/source-date-epoch/

- Move the SOVERSION setting next to where it is used in the library target definition.
  (Moved from CMakeLists.txt to src/CMakeLists.txt)

- Handle math library via codec2 library target and executable target definitions.
  No need for CODEC2_REQUIRED_LIBRARIES everywhere.

- Pass along the lpcnet_freedv.h header as a codec2 library header if needed.
  (Any other lpcnet headers stay private.)

73 de aa4hs,
-Maitland
