### PR TITLE
stm32 ctest maintenance

### DIFF
--- a/stm32/README.md
+++ b/stm32/README.md
@@ -2,7 +2,11 @@
 
 ## Quickstart
 
-1. Build codec2 for your host system, see [codec2/README.md](../README.md)
+1. Build codec2 (with -DUNITTEST=1) for your host system, see [codec2/README.md](../README.md)
+   ```
+   $ cd ~/codec2
+   $ mkdir build_linux && cd build_linux && cmake -DUNITTEST=1 .. && make
+   ```
 
 2. Install a gcc arm toolchain:
    ```

--- a/stm32/unittest/README_unittest.md
+++ b/stm32/unittest/README_unittest.md
@@ -14,11 +14,11 @@ Requirements:
 * STM32F4xx_DSP_StdPeriph_Lib_V1.8.0 (see codec2/stm32/README.md)
 * build openocd from source and have it in your path (see below)
 
-Build codec2 for x86 Linux and run the ctests.  This generates several artifacts required for the stm32 tests:
+Build codec2 for x86 Linux with unittests.  This generates several artifacts required for the stm32 tests:
 
 ```
 $ cd ~/codec2
-$ mkdir build_linux && cd build_linux && cmake .. && make && ctest
+$ mkdir build_linux && cd build_linux && cmake -DUNITTEST=1 .. && make
 ```
 
 Now build for the stm32, and run the stm32 ctests:

--- a/stm32/unittest/scripts/tst_api_demod_setup
+++ b/stm32/unittest/scripts/tst_api_demod_setup
@@ -80,7 +80,7 @@ case "${TEST_OPT}" in
 		>> setup.log 2>&1
 	#
         # Reference - give it a hard time with some noise to exercise the LDPC codec and get us to max CPU
-	ch mod_bits.raw stm_in.raw -20 -f -5 2>&1 | tee setup.log
+	ch mod_bits.raw stm_in.raw --No -20 -f -5 2>&1 | tee setup.log
         freedv_rx 700D stm_in.raw ref_demod.raw -v \
 		> ref_gen.log 2>&1
 	;;

--- a/stm32/unittest/src/tst_api_demod.c
+++ b/stm32/unittest/src/tst_api_demod.c
@@ -96,7 +96,7 @@ void my_datatx(void *callback_state, unsigned char *packet, size_t *size) {
     *size = 0;
 }
 
-#define SPARE_RAM 4000
+#define SPARE_RAM 3000
 
 int main(int argc, char *argv[]) {
     char           dummy[SPARE_RAM];

--- a/stm32/unittest/src/tst_ofdm_demod.c
+++ b/stm32/unittest/src/tst_ofdm_demod.c
@@ -318,11 +318,17 @@ int main(int argc, char *argv[]) {
                 }
             } else {    // !llrs_en (or ldpc_en)
 
-                /* simple hard decision output for uncoded testing, all bits in frame dumped inlcuding UW and txt */
-                for(i=0; i<ofdm_bitsperframe; i++) {
-                    rx_bits_char[i] = rx_bits[i];
+                /* simple hard decision output for uncoded testing, excluding UW and txt */
+                assert(coded_syms_per_frame*ofdm_config->bps == coded_bits_per_frame);
+                for (i = 0; i < coded_syms_per_frame; i++) {
+                    int bits[2];
+                    complex float s = payload_syms[i].real + I * payload_syms[i].imag;
+                    qpsk_demod(s, bits);
+                    rx_bits_char[ofdm_config->bps * i] = bits[1];
+                    rx_bits_char[ofdm_config->bps * i + 1] = bits[0];
                 }
-                fwrite(rx_bits_char, sizeof(char), ofdm_bitsperframe, fout);
+
+                fwrite(rx_bits_char, sizeof (uint8_t), coded_bits_per_frame, fout);
             }
 
             /* optional error counting on uncoded data in non-LDPC testframe mode */


### PR DESCRIPTION
Several stm32 ctests have broken between v1.0.1 and https://github.com/drowe67/codec2/commit/842c566aa33b7e6e0a91e5395cf47fc8889b8d8a, as per commit comments.

The spare RAM was dropped from 4000 to 3000 bytes in `tst_api_demod.c` in order to get `tst_api_demod 700E_AWGN_test` to stop choking when it achieved sync.  Curiously, the other 700D and 700E tests were still running OK with 4000 bytes spare (including the tests that used the codec).  This suggests when we do BER tests with test frames, we need a bit more RAM.  Test frame mode BER tests aren't run on the SM1000 (we always decode to speech), so we are probably OK.

Status:
1. 28/28 stm32 ctests passing :heavy_check_mark: 
2. Try this build on a SM1000.

