### PR TITLE
Resolve compiler error when used with ESP-IDF 5.0.

### DIFF
--- a/src/fdmdv.c
+++ b/src/fdmdv.c
@@ -1021,7 +1021,7 @@ void rxdec_filter(COMP rx_fdm_filter[], COMP rx_fdm[], COMP rxdec_lpf_mem[], int
 
 \*---------------------------------------------------------------------------*/
 
-static void fir_filter2(float acc[2], float mem[], const float coeff[], const unsigned int dec_rate) {
+static void fir_filter2(float acc[], float mem[], const float coeff[], const unsigned int dec_rate) {
     acc[0] = 0.0;
     acc[1] = 0.0;
 


### PR DESCRIPTION
When using codec2 with ESP-IDF 5.0 for ezDV, I get the following error:

```
/Users/mooneer/ezDV/firmware/build/_deps/codec2-src/src/fdmdv.c: In function 'down_convert_and_rx_filter':
/Users/mooneer/ezDV/firmware/build/_deps/codec2-src/src/fdmdv.c:1209:13: error: 'fir_filter2' accessing 8 bytes in a region of size 4 [-Werror=stringop-overflow=]
 1209 |             fir_filter2(&rx_filt[c][k].real,&rx_baseband[st+i].real, gt_alpha5_root, dec_rate);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/mooneer/ezDV/firmware/build/_deps/codec2-src/src/fdmdv.c:1209:13: note: referencing argument 1 of type 'float *'
/Users/mooneer/ezDV/firmware/build/_deps/codec2-src/src/fdmdv.c:1024:13: note: in a call to function 'fir_filter2'
 1024 | static void fir_filter2(float acc[2], float mem[], const float coeff[], const unsigned int dec_rate) {
      |             ^~~~~~~~~~~
```

This PR removes the "2" from the function signature, which allows libcodec2 to be built for ESP32 again.
