### PR TITLE
Add embedded-only memory allocation wrapper.

### DIFF
--- a/src/debug_alloc.h
+++ b/src/debug_alloc.h
@@ -17,8 +17,18 @@ extern char * __heap_end;
 register char * sp asm ("sp");
 #endif
 
+#if defined(__EMBEDDED__)
+extern void* codec2_malloc(size_t size);
+extern void* codec2_calloc(size_t nmemb, size_t size);
+extern void codec2_free(void* ptr);
+#else
+#define codec2_malloc(size) (malloc(size))
+#define codec2_calloc(nmemb, size) (calloc(nmemb, size))
+#define codec2_free(ptr) (free(ptr))
+#endif // defined(__EMBEDDED__)
+
   static inline void * DEBUG_MALLOC(const char *func, size_t size) {
-    void *ptr = malloc(size);
+    void *ptr = codec2_malloc(size);
     fprintf(stderr, "MALLOC: %s %p %d", func, ptr, (int)size);
 #ifdef CORTEX_M4
 
@@ -30,7 +40,7 @@ register char * sp asm ("sp");
     }
 
   static inline void * DEBUG_CALLOC(const char *func, size_t nmemb, size_t size) {
-    void *ptr = calloc(nmemb, size);
+    void *ptr = codec2_calloc(nmemb, size);
     fprintf(stderr, "CALLOC: %s %p %d %d", func, ptr, (int)nmemb, (int)size);
 #ifdef CORTEX_M4
     fprintf(stderr, " : sp %p ", sp);
@@ -40,7 +50,7 @@ register char * sp asm ("sp");
     return(ptr);
     }
   static inline void DEBUG_FREE(const char *func, void *ptr) {
-    free(ptr);
+    codec2_free(ptr);
     fprintf(stderr, "FREE: %s %p\n", func, ptr);
     }
 
@@ -50,11 +60,11 @@ register char * sp asm ("sp");
   #define FREE(ptr) DEBUG_FREE(__func__, ptr)
 #else //DEBUG_ALLOC
 // Default to normal calls
-  #define MALLOC(size) malloc(size)
+  #define MALLOC(size) codec2_malloc(size)
 
-  #define CALLOC(nmemb, size) calloc(nmemb, size)
+  #define CALLOC(nmemb, size) codec2_calloc(nmemb, size)
 
-  #define FREE(ptr) free(ptr)
+  #define FREE(ptr) codec2_free(ptr)
 
 #endif //DEBUG_ALLOC
 

--- a/stm32/src/memtools.c
+++ b/stm32/src/memtools.c
@@ -5,6 +5,7 @@
   Tools for looking at memory on the stm32.  See also debug_alloc.h
 */
 
+#include <stdlib.h>
 #include <sys/types.h>
 #include <math.h>
 #include "memtools.h"

--- a/stm32/src/memtools.c
+++ b/stm32/src/memtools.c
@@ -9,6 +9,22 @@
 #include <math.h>
 #include "memtools.h"
 
+/* Required memory allocation wrapper for embedded platforms. For SM1000, we can just use stdlib's memory functions. */
+void* codec2_malloc(size_t size)
+{
+    return malloc(size);
+}
+
+void* codec2_calloc(size_t nmemb, size_t size)
+{
+    return calloc(nmemb, size);
+}
+
+void codec2_free(void* ptr)
+{
+    free(ptr);
+}
+
 /* startup_stm32f4xx.s has been modified to fill RAM segment from bss up with 0x0x55555555 */
 
 void memtools_find_unused( int (*printf_func)(const char *fmt, ...) ) {


### PR DESCRIPTION
For ezDV (and likely other embedded platforms), it would be good to have more control over allocation from the heap. This PR reassigns most allocation in Codec2 so that it uses `codec2_malloc()`, `codec2_calloc()` and `codec2_free()` instead of the normal `malloc()` / `calloc()` / `free()` functions, with the embedded platform responsible for defining those accordingly. 

(Note: SM1000 simply calls the stdlib versions but ezDV will probably need to call e.g. `heap_caps_malloc(n, MALLOC_CAP_SPIRAM | MALLOC_CAP_32BIT)` to avoid accidentally causing OOM issues in things like the Wi-Fi driver.)