### PR TITLE
Force stdin and stdout to be binary on win32 for helper applications.

### DIFF
--- a/src/c2dec.c
+++ b/src/c2dec.c
@@ -36,6 +36,11 @@
 #include <errno.h>
 #include <getopt.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #define NONE          0  /* no bit errors                          */
 #define UNIFORM       1  /* random bit errors                      */
 #define TWO_STATE     2  /* Two state error model                  */
@@ -99,13 +104,21 @@ int main(int argc, char *argv[])
          argv[2], strerror(errno));
 	exit(1);
     }
-
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+#endif /* _WIN32 */
+    
     if (strcmp(argv[3], "-") == 0) fout = stdout;
     else if ( (fout = fopen(argv[3],"wb")) == NULL ) {
 	fprintf(stderr, "Error opening output speech file: %s: %s.\n",
          argv[3], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     // Attempt to detect a .c2 file with a header
     struct c2_header in_hdr;

--- a/src/c2enc.c
+++ b/src/c2enc.c
@@ -35,6 +35,11 @@
 #include <errno.h>
 #include <math.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 int main(int argc, char *argv[])
 {
     int            mode;
@@ -86,6 +91,10 @@ int main(int argc, char *argv[])
          argv[2], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+#endif /* _WIN32 */
 
     if (strcmp(argv[3], "-") == 0) fout = stdout;
     else if ( (fout = fopen(argv[3],"wb")) == NULL ) {
@@ -93,6 +102,10 @@ int main(int argc, char *argv[])
          argv[3], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
     
     // Write a header if we're writing to a .c2 file
     char *ext = strrchr(argv[3], '.');

--- a/src/c2sim.c
+++ b/src/c2sim.c
@@ -36,6 +36,11 @@
 #include <unistd.h>
 #include <getopt.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "defines.h"
 #include "sine.h"
 #include "nlp.h"
@@ -441,6 +446,28 @@ int main(int argc, char *argv[])
 		argv[optind], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    if (fin != NULL)
+    {
+        setmode(fileno(fin), O_BINARY);
+    }
+    
+    if (fout != NULL)
+    {
+        setmode(fileno(fout), O_BINARY);
+    }
+    
+    if (fmodelin != NULL)
+    {
+        setmode(fileno(fmodelin), O_BINARY);
+    }
+    
+    if (fmodelout != NULL)
+    {
+        setmode(fileno(fmodelout), O_BINARY);
+    }
+#endif /* _WIN32 */
 
     C2CONST c2const = c2const_create(Fs, framelength_s);
     int   n_samp = c2const.n_samp;

--- a/src/ch.c
+++ b/src/ch.c
@@ -33,6 +33,11 @@
 #include <errno.h>
 #include <getopt.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "freedv_api.h"
 #include "codec2_cohpsk.h"
 #include "comp_prim.h"
@@ -130,6 +135,11 @@ int main(int argc, char *argv[])
                 argv[2], strerror(errno));
         exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     NodB = -100;
     Fs = 8000; foff_hz = 0.0; fading_en = 0; ctest = 0;

--- a/src/cohpsk_demod.c
+++ b/src/cohpsk_demod.c
@@ -34,6 +34,11 @@
 #include <errno.h>
 #include <getopt.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "codec2_cohpsk.h"
 #include "cohpsk_defs.h"
 #include "cohpsk_internal.h"
@@ -146,6 +151,11 @@ int main(int argc, char *argv[])
          argv[2], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     cohpsk = cohpsk_create();
     cohpsk_set_verbose(cohpsk, verbose);

--- a/src/cohpsk_get_test_bits.c
+++ b/src/cohpsk_get_test_bits.c
@@ -33,6 +33,11 @@
 #include <math.h>
 #include <errno.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "codec2_cohpsk.h"
 #include "test_bits_coh.h"
 
@@ -56,6 +61,10 @@ int main(int argc, char *argv[])
 	exit(1);
     }
 
+#ifdef _WIN32
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
+    
     ptest_bits_coh = (int*)test_bits_coh;
     ptest_bits_coh_end = (int*)test_bits_coh + sizeof(test_bits_coh)/sizeof(int);
     numBits = atoi(argv[2]);

--- a/src/cohpsk_mod.c
+++ b/src/cohpsk_mod.c
@@ -34,6 +34,11 @@
 #include <math.h>
 #include <errno.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "codec2_cohpsk.h"
 #include "codec2_fdmdv.h"
 
@@ -80,6 +85,11 @@ int main(int argc, char *argv[])
          argv[2], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     cohpsk = cohpsk_create();
 

--- a/src/cohpsk_put_test_bits.c
+++ b/src/cohpsk_put_test_bits.c
@@ -35,6 +35,11 @@
 #include <math.h>
 #include <errno.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "codec2_cohpsk.h"
 #include "octave.h"
 
@@ -65,6 +70,10 @@ int main(int argc, char *argv[])
 	exit(1);
     }
 
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+#endif /* _WIN32 */
+    
     coh = cohpsk_create();
 
     foct = NULL;

--- a/src/deframer.c
+++ b/src/deframer.c
@@ -29,6 +29,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "fsk.h"
 
 unsigned int toInt(char c)
@@ -65,6 +71,11 @@ int main(int argc,char *argv[]){
             exit(1);
         }
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     /* extract UW array from hex on command line */
     

--- a/src/fdmdv_demod.c
+++ b/src/fdmdv_demod.c
@@ -40,6 +40,11 @@
 #include <math.h>
 #include <errno.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "codec2_fdmdv.h"
 #include "octave.h"
 #include "freedv_api.h"
@@ -101,6 +106,11 @@ int main(int argc, char *argv[])
          argv[2], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     if (argc >= 4) {
         Nc = atoi(argv[3]);

--- a/src/fdmdv_get_test_bits.c
+++ b/src/fdmdv_get_test_bits.c
@@ -33,6 +33,11 @@
 #include <math.h>
 #include <errno.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "codec2_fdmdv.h"
 
 int main(int argc, char *argv[])
@@ -60,6 +65,10 @@ int main(int argc, char *argv[])
          argv[1], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     numBits = atoi(argv[2]);
 

--- a/src/fdmdv_mod.c
+++ b/src/fdmdv_mod.c
@@ -36,6 +36,11 @@
 #include <math.h>
 #include <errno.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "codec2_fdmdv.h"
 
 int main(int argc, char *argv[])
@@ -77,6 +82,11 @@ int main(int argc, char *argv[])
          argv[2], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     if (argc == 4) {
         Nc = atoi(argv[3]);

--- a/src/fdmdv_put_test_bits.c
+++ b/src/fdmdv_put_test_bits.c
@@ -34,6 +34,11 @@
 #include <math.h>
 #include <errno.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "codec2_fdmdv.h"
 
 int main(int argc, char *argv[])
@@ -63,6 +68,10 @@ int main(int argc, char *argv[])
          argv[1], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+#endif /* _WIN32 */
 
     if (argc == 3) {
         Nc = atoi(argv[2]);

--- a/src/fm_demod.c
+++ b/src/fm_demod.c
@@ -33,6 +33,11 @@
 #include <math.h>
 #include <errno.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "codec2_fm.h"
 #include "octave.h"
 
@@ -71,6 +76,11 @@ int main(int argc, char *argv[])
          argv[2], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     fm         = fm_create(N);
     fm->Fs     = 48000.0;

--- a/src/fmfsk_demod.c
+++ b/src/fmfsk_demod.c
@@ -30,6 +30,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "fmfsk.h"
 #include "modem_stats.h"
 #define MODEMPROBE_ENABLE
@@ -72,6 +78,11 @@ int main(int argc,char *argv[]){
 	fout = fopen(argv[4],"w");
     }
 	
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
+    
     /* set up FSK */
     fmfsk = fmfsk_create(Fs,Rb);
 

--- a/src/fmfsk_mod.c
+++ b/src/fmfsk_mod.c
@@ -31,6 +31,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "fmfsk.h"
 #include "codec2_fdmdv.h"
 
@@ -64,6 +70,10 @@ int main(int argc,char *argv[]){
 		fout = fopen(argv[4],"w");
 	}
     
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
     
     /* set up FMFSK */
     fmfsk = fmfsk_create(Fs,Rb);

--- a/src/framer.c
+++ b/src/framer.c
@@ -31,6 +31,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "fsk.h"
 
 unsigned int toInt(char c)
@@ -66,6 +72,11 @@ int main(int argc,char *argv[]){
             exit(1);
         }
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     /* extract UW array */
     

--- a/src/freedv_data_raw_rx.c
+++ b/src/freedv_data_raw_rx.c
@@ -34,6 +34,11 @@
 #include <getopt.h>
 #include <signal.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "freedv_api.h"
 #include "modem_stats.h"
 #include "octave.h"
@@ -176,6 +181,11 @@ int main(int argc, char *argv[]) {
                argv[3], strerror(errno));
 	     exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     if (mode != FREEDV_MODE_FSK_LDPC)
         freedv = freedv_open(mode);

--- a/src/freedv_data_raw_tx.c
+++ b/src/freedv_data_raw_tx.c
@@ -34,6 +34,11 @@
 #include <stdint.h>
 #include <getopt.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "freedv_api.h"
 #include "fsk.h"
 #include "ofdm_internal.h"
@@ -207,6 +212,11 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Error opening output modem sample file: %s: %s.\n", argv[dx+2], strerror(errno));
         exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     if (mode != FREEDV_MODE_FSK_LDPC)
         freedv = freedv_open(mode);

--- a/src/freedv_data_rx.c
+++ b/src/freedv_data_rx.c
@@ -34,6 +34,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "freedv_api.h"
 
 /**********************************************************
@@ -186,6 +191,10 @@ int main(int argc, char *argv[]) {
          argv[2], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+#endif /* _WIN32 */
 
     verbose = 0;
     

--- a/src/freedv_data_tx.c
+++ b/src/freedv_data_tx.c
@@ -34,6 +34,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "freedv_api.h"
 #include "codec2.h"
 
@@ -221,6 +226,10 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Error opening output modem sample file: %s: %s.\n", argv[3], strerror(errno));
         exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     if (argc > 3) {
         for (i = 3; i < argc; i++) {

--- a/src/freedv_mixed_rx.c
+++ b/src/freedv_mixed_rx.c
@@ -34,6 +34,11 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "freedv_api.h"
 #include "modem_stats.h"
 
@@ -109,6 +114,11 @@ int main(int argc, char *argv[]) {
          argv[3], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     use_codecrx = 0; verbose = 0;
     

--- a/src/freedv_mixed_tx.c
+++ b/src/freedv_mixed_tx.c
@@ -35,6 +35,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "freedv_api.h"
 #include "codec2.h"
 
@@ -247,6 +252,11 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Error opening output modem sample file: %s: %s.\n", argv[3], strerror(errno));
         exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     use_codectx = 0;
     

--- a/src/freedv_rx.c
+++ b/src/freedv_rx.c
@@ -37,6 +37,11 @@
 #include <errno.h>
 #include <getopt.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "reliable_text.h"
 #include "freedv_api.h"
 #include "modem_stats.h"
@@ -194,6 +199,11 @@ int main(int argc, char *argv[]) {
                 argv[dx+2], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     freedv = freedv_open(mode);
     assert(freedv != NULL);

--- a/src/freedv_tx.c
+++ b/src/freedv_tx.c
@@ -32,6 +32,11 @@
 #include <errno.h>
 #include <getopt.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "reliable_text.h"
 #include "freedv_api.h"
 
@@ -160,6 +165,11 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Error opening output modem sample file: %s: %s.\n", argv[dx+2], strerror(errno));
         exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     freedv = freedv_open(mode);
     assert(freedv != NULL);

--- a/src/fsk_demod.c
+++ b/src/fsk_demod.c
@@ -36,6 +36,11 @@
 #include <signal.h>
 #include <unistd.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "fsk.h"
 #include "codec2_fdmdv.h"
 #include "mpdecode_core.h"
@@ -205,6 +210,11 @@ int main(int argc,char *argv[]){
     }else{
         fout = fopen(argv[dx + 4],"w");
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     /* set up FSK */
     fsk = fsk_create_hbr(Fs,Rs,M,P,nsym,FSK_NONE,tone_separation);

--- a/src/fsk_get_test_bits.c
+++ b/src/fsk_get_test_bits.c
@@ -30,6 +30,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "fsk.h"
 
 #define TEST_FRAME_SIZE 100  /* arbitrary choice, repeats after this
@@ -71,6 +77,10 @@ int main(int argc,char *argv[]){
         fprintf(stderr,"Couldn't open output file: %s\n", argv[1]);
         exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
     
     /* allocate buffers for processing */
     bitbuf = (uint8_t*)malloc(sizeof(uint8_t)*framesize);

--- a/src/fsk_mod.c
+++ b/src/fsk_mod.c
@@ -28,6 +28,12 @@
 #include <stdio.h>
 #include <string.h>
 #include <getopt.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "fsk.h"
 #include "codec2_fdmdv.h"
 
@@ -93,6 +99,11 @@ int main(int argc,char *argv[]){
     }else{
         fout = fopen(argv[optind],"w");
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     /* p is not actually used for the modulator, but we need to set it for fsk_create() to be happy */    
     if (!user_p)

--- a/src/fsk_mod_ext_vco.c
+++ b/src/fsk_mod_ext_vco.c
@@ -33,6 +33,11 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #define OVERSAMPLE 100
 
 int main(int argc,char *argv[]){
@@ -62,6 +67,11 @@ int main(int argc,char *argv[]){
     } else {
         fout = fopen(argv[2],"w");
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
     
     m = atoi(argv[3]); log2m = log2(m);
     printf("log2m: %d\n", log2m);

--- a/src/fsk_put_test_bits.c
+++ b/src/fsk_put_test_bits.c
@@ -31,6 +31,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <getopt.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "fsk.h"
 
 #define TEST_FRAME_SIZE 100  /* must match fsk_get_test_bits.c */
@@ -103,6 +109,10 @@ int main(int argc,char *argv[]){
         fprintf(stderr,"Couldn't open input file: %s\n", argv[1]);
         exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+#endif /* _WIN32 */
 
     /* allocate buffers for processing */
     bitbuf_tx = (uint8_t*)malloc(sizeof(uint8_t)*framesize);

--- a/src/ldpc_dec.c
+++ b/src/ldpc_dec.c
@@ -15,6 +15,11 @@
 #include <string.h>
 #include <stdio.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "mpdecode_core.h"
 #include "ldpc_codes.h"
 #include "ofdm_internal.h"
@@ -107,6 +112,11 @@ int main(int argc, char *argv[])
                 argv[2], strerror(errno));
         exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     sdinput = 0; mute = 0; testframes = 0;
     if (opt_exists(argv, argc, "--sd")) {

--- a/src/ldpc_enc.c
+++ b/src/ldpc_enc.c
@@ -13,6 +13,11 @@
 #include <string.h>
 #include <errno.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "mpdecode_core.h"
 #include "ldpc_codes.h"
 #include "ofdm_internal.h"
@@ -79,6 +84,11 @@ int main(int argc, char *argv[])
                 argv[2], strerror(errno));
         exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
     
     sd = 0;
     if (opt_exists(argv, argc, "--sd")) {

--- a/src/ldpc_noise.c
+++ b/src/ldpc_noise.c
@@ -14,6 +14,11 @@
 #include <math.h>
 #include <errno.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 int main(int argc, char *argv[]) {
     FILE        *fin, *fout;
     float	datain, dataout;
@@ -38,6 +43,11 @@ int main(int argc, char *argv[]) {
                 argv[2], strerror(errno));
         exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     double NodB = atof(argv[3]);
     double No = pow(10.0, NodB/10.0);

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -39,6 +39,11 @@
 #include <math.h>
 #include <errno.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "codec2_ofdm.h"
 #include "ofdm_internal.h"
 #include "octave.h"
@@ -268,6 +273,11 @@ int main(int argc, char *argv[]) {
             exit(-1);
         }
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     if (log_specified == true) {
         if ((foct = fopen(log_name, "wt")) == NULL) {

--- a/src/ofdm_get_test_bits.c
+++ b/src/ofdm_get_test_bits.c
@@ -36,6 +36,11 @@
 #include <math.h>
 #include <errno.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "codec2_ofdm.h"
 #include "ofdm_internal.h"
 #include "ldpc_codes.h"
@@ -132,6 +137,10 @@ int main(int argc, char *argv[])
             exit(-1);
         }
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     if (verbose)
         fprintf(stderr, "Nframes: %d Ndatabitsperframe: %d bcb: %d\n", Nframes, Ndatabitsperpacket, bcb_en);

--- a/src/ofdm_mod.c
+++ b/src/ofdm_mod.c
@@ -37,6 +37,11 @@
 #include <string.h>
 #include <math.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "codec2_ofdm.h"
 #include "ofdm_internal.h"
 #include "gp_interleaver.h"
@@ -235,6 +240,11 @@ int main(int argc, char *argv[]) {
             exit(-1);
         }
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
 
     /* init the modem with our (optionally) custom config */
     struct OFDM *ofdm = ofdm_create(ofdm_config);

--- a/src/ofdm_put_test_bits.c
+++ b/src/ofdm_put_test_bits.c
@@ -33,6 +33,11 @@
 #include <math.h>
 #include <errno.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "codec2_ofdm.h"
 #include "ofdm_internal.h"
 #include "test_bits_ofdm.h"
@@ -72,6 +77,10 @@ int main(int argc, char *argv[])
          argv[1], strerror(errno));
 	exit(1);
     }
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+#endif /* _WIN32 */
 
     verbose = 0;
     if (opt_exists(argv, argc, "-v")) {

--- a/src/tollr.c
+++ b/src/tollr.c
@@ -9,8 +9,19 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 int main(void) {
     uint8_t bit;
+    
+#ifdef _WIN32
+    setmode(fileno(stdin), O_BINARY);
+    setmode(fileno(stdout), O_BINARY);
+#endif /* _WIN32 */
+    
     while(fread(&bit,sizeof(uint8_t), 1, stdin)) {
         float llr = 10.0*(1-2*bit);
         fwrite(&llr,sizeof(float),1,stdout);

--- a/src/vhf_deframe_c2.c
+++ b/src/vhf_deframe_c2.c
@@ -31,6 +31,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "freedv_vhf_framing.h"
 
 int main(int argc,char *argv[]){
@@ -60,15 +66,20 @@ int main(int argc,char *argv[]){
     if(strcmp(argv[2],"-")==0){
         fin = stdin;
     }else{
-        fin = fopen(argv[2],"r");
+        fin = fopen(argv[2],"rb");
     }
 	
     if(strcmp(argv[3],"-")==0){
         fout = stdout;
     }else{
-        fout = fopen(argv[3],"w");
+        fout = fopen(argv[3],"wb");
     }
 
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
+    
     /* Set up deframer */
     deframer = fvhff_create_deframer(frame_fmt,0);
     

--- a/src/vhf_frame_c2.c
+++ b/src/vhf_frame_c2.c
@@ -31,6 +31,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif /* _WIN32 */
+
 #include "freedv_vhf_framing.h"
 
 int main(int argc,char *argv[]){
@@ -59,15 +65,20 @@ int main(int argc,char *argv[]){
     if(strcmp(argv[2],"-")==0){
         fin = stdin;
     }else{
-        fin = fopen(argv[2],"r");
+        fin = fopen(argv[2],"rb");
     }
 	
     if(strcmp(argv[3],"-")==0){
         fout = stdout;
     }else{
-        fout = fopen(argv[3],"w");
+        fout = fopen(argv[3],"wb");
     }
-
+    
+#ifdef _WIN32
+    setmode(fileno(fin), O_BINARY);
+    setmode(fileno(fout), O_BINARY);
+#endif /* _WIN32 */
+    
     /* Set up deframer */
     deframer = fvhff_create_deframer(frame_fmt,0);
     


### PR DESCRIPTION
Per #357, while we are passing "b" to `fopen()` calls in the applications we provide, we don't do similar for stdin/stdout, causing confusion for Windows users. This PR adds the necessary code to allow piping between applications to work properly.

(Thanks @gvanem for the initial fix!)