### PR TITLE
Add CMAKE_OSX_DEPLOYMENT_TARGET to top of CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@
 # Please report questions, comments, problems, or patches to the freetel
 # mailing list: https://lists.sourceforge.net/lists/listinfo/freetel-codec2
 #
+
+# Note: this has to be at the beginning of the file in order for CMake to 
+# actually recognize this override (vs. simply telling the macOS build toolchain
+# to mandate the current release).
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
+
 cmake_minimum_required(VERSION 3.13)
 project(CODEC2
   VERSION 1.0.7


### PR DESCRIPTION
This PR adds an override for `CMAKE_OSX_DEPLOYMENT_TARGET` to the top of CMakeLists.txt to ensure that (a) Codec2 packages can properly run on older macOS and (b) freedv-gui can properly set `CMAKE_OSX_DEPLOYMENT_TARGET` for itself.

Note that LPCNet already does this, so no changes are required for that package. See https://github.com/drowe67/LPCNet/blob/master/CMakeLists.txt#L5.