### PR TITLE
Apply workaround for newer CMake (e.g. Fedora 37)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,11 @@ include_directories(${PROJECT_BINARY_DIR})
 #
 if(LPCNET)
     if(LPCNET_BUILD_DIR)
+        # Theoretically this shouldn't be needed as we're also defining LPCNET_BUILD_DIR
+        # in the PATHS section below. But on Fedora 37, CMake can't find LPCNet (at least
+        # in Docker) without this.
         set(lpcnetfreedv_DIR ${LPCNET_BUILD_DIR})
+        
         find_package(lpcnetfreedv REQUIRED
             PATHS ${LPCNET_BUILD_DIR}
             NO_DEFAULT_PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ include_directories(${PROJECT_BINARY_DIR})
 #
 if(LPCNET)
     if(LPCNET_BUILD_DIR)
+        set(lpcnetfreedv_DIR ${LPCNET_BUILD_DIR})
         find_package(lpcnetfreedv REQUIRED
             PATHS ${LPCNET_BUILD_DIR}
             NO_DEFAULT_PATH


### PR DESCRIPTION
Not sure why but the newest CMake (e.g. as used in Fedora 37/the latest freedv-gui Docker container) doesn't seem to handle `PATHS` in `find_package` properly. This PR manually sets `lpcnetfreedv_DIR` so that `find_package` immediately checks it for the required `lpcnetfreedv.cmake` file.