### PR TITLE
refactor to use type 'bool' consistently

### DIFF
--- a/src/codec2.c
+++ b/src/codec2.c
@@ -206,7 +206,7 @@ struct CODEC2 * codec2_create(int mode)
     c2->smoothing = 0;
     c2->se = 0.0; c2->nse = 0;
     c2->user_rate_K_vec_no_mean_ = NULL;
-    c2->post_filter_en = 1;
+    c2->post_filter_en = true;
     
     c2->bpf_buf = (float*)MALLOC(sizeof(float)*(BPF_N+4*c2->n_samp));
     assert(c2->bpf_buf != NULL);
@@ -225,7 +225,7 @@ struct CODEC2 * codec2_create(int mode)
             c2->prev_rate_K_vec_[k] = 0.0;
             c2->eq[k] = 0.0;
         }
-        c2->eq_en = 0;
+        c2->eq_en = false;
         c2->Wo_left = 0.0;
         c2->voicing_left = 0;;
         c2->phase_fft_fwd_cfg = codec2_fft_alloc(NEWAMP1_PHASE_NFFT, 0, NULL, NULL);
@@ -2296,11 +2296,11 @@ float *codec2_enable_user_ratek(struct CODEC2 *codec2_state, int *K) {
     return codec2_state->user_rate_K_vec_no_mean_;
 }
 
-void codec2_700c_post_filter(struct CODEC2 *codec2_state, int en) {
+void codec2_700c_post_filter(struct CODEC2 *codec2_state, bool en) {
     codec2_state->post_filter_en = en;
 }
 
-void codec2_700c_eq(struct CODEC2 *codec2_state, int en) {
+void codec2_700c_eq(struct CODEC2 *codec2_state, bool en) {
     codec2_state->eq_en = en;
     codec2_state->se = 0.0; codec2_state->nse = 0;
 }

--- a/src/codec2.h
+++ b/src/codec2.h
@@ -28,7 +28,7 @@
 
 #ifndef __CODEC2__
 #define  __CODEC2__
-
+#include <stdbool.h>
 #include <codec2/version.h>
 
 #ifdef __cplusplus
@@ -112,8 +112,8 @@ float codec2_get_var(struct CODEC2 *codec2_state);
 float *codec2_enable_user_ratek(struct CODEC2 *codec2_state, int *K);
 
 // 700C post filter and equaliser
-void codec2_700c_post_filter(struct CODEC2 *codec2_state, int en);
-void codec2_700c_eq(struct CODEC2 *codec2_state, int en);
+void codec2_700c_post_filter(struct CODEC2 *codec2_state, bool en);
+void codec2_700c_eq(struct CODEC2 *codec2_state, bool en);
       
 #ifdef __cplusplus
 }

--- a/src/codec2_internal.h
+++ b/src/codec2_internal.h
@@ -28,6 +28,7 @@
 
 #ifndef __CODEC2_INTERNAL__
 #define __CODEC2_INTERNAL__
+#include <stdbool.h>
 
 #include "codec2_fft.h"
 #include "newamp1.h"
@@ -81,9 +82,9 @@ struct CODEC2 {
     float          se;                       /* running sum of squared error */
     unsigned int   nse;                      /* number of terms in sum       */
     float         *user_rate_K_vec_no_mean_; /* optional, user supplied vector for quantisation experiments */
-    int            post_filter_en;
+    bool           post_filter_en;
     float          eq[NEWAMP1_K];            /* optional equaliser */
-    int            eq_en;
+    bool           eq_en;
     
     /*newamp2 states (also uses newamp1 states )*/
     float 	   energy_prev;

--- a/src/freedv_1600.c
+++ b/src/freedv_1600.c
@@ -28,7 +28,7 @@
 
 void freedv_1600_open(struct freedv *f) {
     f->snr_squelch_thresh = 2.0;
-    f->squelch_en = 1;
+    f->squelch_en = true;
     f->tx_sync_bit = 0;
     int Nc = 16;
     f->fdmdv = fdmdv_create(Nc);

--- a/src/freedv_2020.c
+++ b/src/freedv_2020.c
@@ -120,7 +120,7 @@ void freedv_2020x_open(struct freedv *f) {
     f->n_nom_modem_samples = ofdm_get_samples_per_frame(f->ofdm);
     f->n_max_modem_samples = ofdm_get_max_samples_per_frame(f->ofdm);
     f->modem_sample_rate = f->ofdm->config.fs;
-    f->clip_en = 0;
+    f->clip_en = false;
     f->sz_error_pattern = f->ofdm_bitsperframe;
 
     /* storage for pass through audio interpolating filter.  These are

--- a/src/freedv_700.c
+++ b/src/freedv_700.c
@@ -39,7 +39,7 @@ extern char *ofdm_statemode[];
 
 void freedv_700c_open(struct freedv *f) {
     f->snr_squelch_thresh = 0.0;
-    f->squelch_en = 0;
+    f->squelch_en = false;
 
     f->cohpsk = cohpsk_create();
     f->nin = f->nin_prev = COHPSK_NOM_SAMPLES_PER_FRAME;
@@ -47,7 +47,7 @@ void freedv_700c_open(struct freedv *f) {
     f->n_nom_modem_samples = f->n_nat_modem_samples * FREEDV_FS_8000 / COHPSK_FS;// number of samples after native samples are interpolated to 8000 sps
     f->n_max_modem_samples = COHPSK_MAX_SAMPLES_PER_FRAME * FREEDV_FS_8000 / COHPSK_FS + 1;
     f->modem_sample_rate = FREEDV_FS_8000;                                       // note weird sample rate tamed by resampling
-    f->clip_en = 1;
+    f->clip_en = true;
     f->sz_error_pattern = cohpsk_error_pattern_size();
     f->test_frames_diversity = 1;
 
@@ -98,7 +98,7 @@ void freedv_comptx_700c(struct freedv *f, COMP mod_out[]) {
 // open function for OFDM voice modes
 void freedv_ofdm_voice_open(struct freedv *f, char *mode) {
     f->snr_squelch_thresh = 0.0;
-    f->squelch_en = 0;
+    f->squelch_en = false;
     struct OFDM_CONFIG *ofdm_config = (struct OFDM_CONFIG *) calloc(1, sizeof (struct OFDM_CONFIG));
     assert(ofdm_config != NULL);
     ofdm_init_mode(mode, ofdm_config);
@@ -135,7 +135,7 @@ void freedv_ofdm_voice_open(struct freedv *f, char *mode) {
     f->n_nom_modem_samples = ofdm_get_samples_per_frame(f->ofdm);
     f->n_max_modem_samples = ofdm_get_max_samples_per_frame(f->ofdm);
     f->modem_sample_rate = f->ofdm->config.fs;
-    f->clip_en = 0;
+    f->clip_en = false;
     f->sz_error_pattern = f->ofdm_bitsperframe;
 
     f->tx_bits = NULL; /* not used for 700D */

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -859,7 +859,7 @@ int freedv_bits_to_speech(struct freedv *f, short speech_out[], short demod_in[]
     int decode_speech = 0;
     if ((rx_status & FREEDV_RX_SYNC) == 0) {
 
-        if (f->squelch_en == 0) {
+        if (!f->squelch_en) {
 
             /* pass through received samples so we can hear what's going on, e.g. during tuning */
 
@@ -889,7 +889,7 @@ int freedv_bits_to_speech(struct freedv *f, short speech_out[], short demod_in[]
        /* following logic is tricky so spell it out clearly, see table
           in: https://github.com/drowe67/codec2/pull/111 */
 
-       if (f->squelch_en == 0) {
+       if (!f->squelch_en) {
            decode_speech = 1;
        } else {
            /* squelch is enabled */
@@ -1241,7 +1241,7 @@ void freedv_get_modem_stats(struct freedv *f, int *sync, float *snr_est)
 
 void freedv_set_test_frames               (struct freedv *f, int val) {f->test_frames = val;}
 void freedv_set_test_frames_diversity	  (struct freedv *f, int val) {f->test_frames_diversity = val;}
-void freedv_set_squelch_en                (struct freedv *f, int val) {f->squelch_en = val;}
+void freedv_set_squelch_en                (struct freedv *f, bool val) {f->squelch_en = val;}
 void freedv_set_total_bit_errors          (struct freedv *f, int val) {f->total_bit_errors = val;}
 void freedv_set_total_bits                (struct freedv *f, int val) {f->total_bits = val;}
 void freedv_set_total_bit_errors_coded    (struct freedv *f, int val) {f->total_bit_errors_coded = val;}
@@ -1256,7 +1256,7 @@ void freedv_passthrough_gain              (struct freedv *f, float g) {f->passth
 
 /* supported by 700C, 700D, 700E */
 
-void freedv_set_clip(struct freedv *f, int val) {
+void freedv_set_clip(struct freedv *f, bool val) {
     f->clip_en = val;
     if (is_ofdm_mode(f)) {
       f->ofdm->clip_en = val;
@@ -1289,7 +1289,7 @@ void freedv_set_phase_est_bandwidth_mode(struct freedv *f, int val) {
 }
 
 // For those FreeDV modes using the codec 2 700C vocoder 700C/D/E/800XA
-void freedv_set_eq(struct freedv *f, int val) {
+void freedv_set_eq(struct freedv *f, bool val) {
     if (f->codec2 != NULL) {
         codec2_700c_eq(f->codec2, val);
     }

--- a/src/freedv_api.h
+++ b/src/freedv_api.h
@@ -35,6 +35,7 @@
 #define __FREEDV_API__
 
 #include <sys/types.h>
+#include <stdbool.h>
 // This declares a single-precision (float) complex number
 #include "comp.h"
 
@@ -225,9 +226,9 @@ void freedv_set_callback_data           (struct freedv *freedv, freedv_callback_
 void freedv_set_test_frames		        (struct freedv *freedv, int test_frames);
 void freedv_set_test_frames_diversity	(struct freedv *freedv, int test_frames_diversity);
 void freedv_set_smooth_symbols		    (struct freedv *freedv, int smooth_symbols);
-void freedv_set_squelch_en		        (struct freedv *freedv, int squelch_en);
+void freedv_set_squelch_en		        (struct freedv *freedv, bool squelch_en);
 void freedv_set_snr_squelch_thresh	    (struct freedv *freedv, float snr_squelch_thresh);
-void freedv_set_clip	                (struct freedv *freedv, int val);
+void freedv_set_clip	                (struct freedv *freedv, bool val);
 void freedv_set_total_bit_errors    	(struct freedv *freedv, int val);
 void freedv_set_total_bits              (struct freedv *freedv, int val);
 void freedv_set_total_bit_errors_coded  (struct freedv *freedv, int val);
@@ -245,7 +246,7 @@ void freedv_set_tx_amp                  (struct freedv *freedv, float amp);
 void freedv_set_dpsk                    (struct freedv *freedv, int val);
 void freedv_set_ext_vco                 (struct freedv *f, int val);
 void freedv_set_phase_est_bandwidth_mode(struct freedv *f, int val);
-void freedv_set_eq                      (struct freedv *f, int val);
+void freedv_set_eq                      (struct freedv *f, bool val);
 void freedv_set_frames_per_burst        (struct freedv *f, int framesperburst);
 void freedv_passthrough_gain            (struct freedv *f, float g);
 int freedv_set_tuning_range             (struct freedv *freedv, float val_fmin, float val_fmax);

--- a/src/freedv_api_internal.h
+++ b/src/freedv_api_internal.h
@@ -127,12 +127,12 @@ struct freedv {
     int                 *tx_bits;                            /* FSK modem frame under construction */
     int                  tx_sync_bit;
     int                  frames;
-    int                  clip_en;                            /* non-zero for modem Tx clipping to lower PAPR */
+    bool                 clip_en;                            /* non-zero for modem Tx clipping to lower PAPR */
     int                  sync;                               /* we set this when a mode is in sync */
     int                  evenframe;
     float                snr_est;                            /* we set this each time the modes's demod estimates SNR */
     float                snr_squelch_thresh;
-    int                  squelch_en;
+    bool                 squelch_en;
     int                  nin, nin_prev;
     int                  verbose;
     int                  ext_vco;                            /* 2400A/800XA use external VCO flag */

--- a/src/freedv_rx.c
+++ b/src/freedv_rx.c
@@ -205,7 +205,7 @@ int main(int argc, char *argv[]) {
     
     if (use_squelch) {
         freedv_set_snr_squelch_thresh(freedv, squelch);
-        freedv_set_squelch_en(freedv, 1);
+        freedv_set_squelch_en(freedv, true);
     }
     freedv_set_dpsk(freedv, use_dpsk);
     if (use_passthroughgain) freedv_passthrough_gain(freedv, passthroughgain);

--- a/src/freedv_tx.c
+++ b/src/freedv_tx.c
@@ -170,7 +170,7 @@ int main(int argc, char *argv[]) {
     freedv_set_tx_bpf(freedv, use_txbpf);
     freedv_set_dpsk(freedv, use_dpsk);
     freedv_set_verbose(freedv, 1);
-    freedv_set_eq(freedv, 1); /* for 700C/D/E & 800XA */
+    freedv_set_eq(freedv, true); /* for 700C/D/E & 800XA */
 
     if (use_reliabletext) {
         reliable_text_obj = reliable_text_create();

--- a/src/ofdm_mod.c
+++ b/src/ofdm_mod.c
@@ -98,7 +98,7 @@ int main(int argc, char *argv[]) {
     int input_specified = 0;
     int output_specified = 0;
     int verbose = 0;
-    int clip_en = 0;
+    bool clip_en = false;
     int txbpf_en = 0;
     int testframes = 0;
     int use_text = 0;
@@ -206,7 +206,7 @@ int main(int argc, char *argv[]) {
                 dpsk = 1;
                 break;
             case 'r':
-                clip_en = 1;
+                clip_en = true;
                 break;
             case 'v':
                 verbose = atoi(options.optarg);


### PR DESCRIPTION
The sources of **freedv-gui** use type _bool_ often but not consistently yet.
Apparently the same goes for the **codec2** sources.
I refactored all "enable" variables  and the interface to use _bool_ types and check for _true_ and _false_,
which also required to add "include <stdbool>" into some source files.