### PR TITLE
Use memcpy() inside codec2_fifo

### DIFF
--- a/unittest/tfifo.c
+++ b/unittest/tfifo.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <pthread.h>
+#include <unistd.h>
 #include "codec2_fifo.h"
 
 #define FIFO_SZ  1024
@@ -25,7 +26,7 @@ void *writer_thread(void *data);
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 #define USE_THREADS
-//#define USE_MUTEX
+#define USE_MUTEX
 
 int main() {
     pthread_t awriter_thread;


### PR DESCRIPTION
This PR performs the following:

1. Addresses TBD comment inside codec2_fifo.c by using memcpy to write/read to FIFO.
2. Enables mutexes in the ctest to prevent macOS failures in test_fifo.