### PR TITLE
Generate slow fading files as part of the build process

### DIFF
--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -114,11 +114,13 @@ ExternalProject_Add(cml
 
 # Create fading files (used for channel simulation) as part of unit test setup
 add_custom_target(fading_files ALL
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/slow_fading_samples.float
   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/fast_fading_samples.float
   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/faster_fading_samples.float
   )
 add_custom_command(
-  OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/fast_fading_samples.float
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/slow_fading_samples.float
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/fast_fading_samples.float
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/faster_fading_samples.float
   COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ./fading_files.sh ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/unittest/fading_files.sh
+++ b/unittest/fading_files.sh
@@ -4,6 +4,9 @@
 
 output_path=$1
 echo "Generating fading files ......"
+cmd='cd ../octave; pkg load signal; ch_fading("'${output_path}'/slow_fading_samples.float", 8000, 0.5, 8000*60)'
+octave --no-gui -qf --eval "$cmd"
+[ ! $? -eq 0 ] && { echo "octave failed to run correctly .... exiting"; exit 1; }
 cmd='cd ../octave; pkg load signal; ch_fading("'${output_path}'/fast_fading_samples.float", 8000, 1.0, 8000*60)'
 octave --no-gui -qf --eval "$cmd"
 [ ! $? -eq 0 ] && { echo "octave failed to run correctly .... exiting"; exit 1; }


### PR DESCRIPTION
During some freedv-gui testing, I found that the `--mpg` flag in `ch` didn't work because `slow_fading_samples.float` wasn't getting generated. This PR causes that file to be built.