### PR TITLE
Issue383 add build executables option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ option(BUILD_SHARED_LIBS
     "Build shared library. Set to OFF for static library." ON)
 option(UNITTEST "Build unittest binaries." OFF)
 option(INSTALL_EXAMPLES "Install example code." OFF)
+option(BUILD_EXECUTABLES "Build executables with all and install targets" ON)
 if(INSTALL_EXAMPLES)
     install(DIRECTORY octave raw script wav
         USE_SOURCE_PERMISSIONS
@@ -218,7 +219,9 @@ endif()
 # codec2 library and demo apps
 #
 add_subdirectory(src)
-add_subdirectory(demo)
+if(BUILD_EXECUTABLES)
+    add_subdirectory(demo)
+endif(BUILD_EXECUTABLES)
 
 
 if(UNITTEST)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -274,124 +274,124 @@ export(TARGETS codec2
 )
 
 if(BUILD_EXECUTABLES)
-add_executable(c2enc c2enc.c)
-target_link_libraries(c2enc codec2)
+    add_executable(c2enc c2enc.c)
+    target_link_libraries(c2enc codec2)
 
-add_executable(c2dec c2dec.c)
-target_link_libraries(c2dec codec2)
+    add_executable(c2dec c2dec.c)
+    target_link_libraries(c2dec codec2)
 
-add_executable(c2sim c2sim.c sd.c)
-target_link_libraries(c2sim codec2)
+    add_executable(c2sim c2sim.c sd.c)
+    target_link_libraries(c2sim codec2)
 
-add_executable(fdmdv_get_test_bits fdmdv_get_test_bits.c fdmdv.c kiss_fft.c codec2_fft.c kiss_fftr.c)
-target_link_libraries(fdmdv_get_test_bits m)
+    add_executable(fdmdv_get_test_bits fdmdv_get_test_bits.c fdmdv.c kiss_fft.c codec2_fft.c kiss_fftr.c)
+    target_link_libraries(fdmdv_get_test_bits m)
 
-add_executable(fdmdv_mod fdmdv_mod.c fdmdv.c kiss_fft.c codec2_fft.c kiss_fftr.c)
-target_link_libraries(fdmdv_mod m)
+    add_executable(fdmdv_mod fdmdv_mod.c fdmdv.c kiss_fft.c codec2_fft.c kiss_fftr.c)
+    target_link_libraries(fdmdv_mod m)
 
-add_executable(fdmdv_demod fdmdv_demod.c fdmdv.c kiss_fft.c octave.c modem_stats.c codec2_fft.c kiss_fftr.c)
-target_link_libraries(fdmdv_demod m)
+    add_executable(fdmdv_demod fdmdv_demod.c fdmdv.c kiss_fft.c octave.c modem_stats.c codec2_fft.c kiss_fftr.c)
+    target_link_libraries(fdmdv_demod m)
 
-add_executable(fdmdv_put_test_bits fdmdv_put_test_bits.c fdmdv.c kiss_fft.c codec2_fft.c kiss_fftr.c)
-target_link_libraries(fdmdv_put_test_bits m)
+    add_executable(fdmdv_put_test_bits fdmdv_put_test_bits.c fdmdv.c kiss_fft.c codec2_fft.c kiss_fftr.c)
+    target_link_libraries(fdmdv_put_test_bits m)
 
-add_executable(freedv_tx freedv_tx.c)
-target_link_libraries(freedv_tx codec2)
+    add_executable(freedv_tx freedv_tx.c)
+    target_link_libraries(freedv_tx codec2)
 
-add_executable(freedv_rx freedv_rx.c)
-target_link_libraries(freedv_rx codec2)
+    add_executable(freedv_rx freedv_rx.c)
+    target_link_libraries(freedv_rx codec2)
 
-add_executable(freedv_data_raw_tx freedv_data_raw_tx.c)
-target_link_libraries(freedv_data_raw_tx codec2)
+    add_executable(freedv_data_raw_tx freedv_data_raw_tx.c)
+    target_link_libraries(freedv_data_raw_tx codec2)
 
-add_executable(freedv_data_raw_rx freedv_data_raw_rx.c octave.c)
-target_link_libraries(freedv_data_raw_rx codec2)
+    add_executable(freedv_data_raw_rx freedv_data_raw_rx.c octave.c)
+    target_link_libraries(freedv_data_raw_rx codec2)
 
-add_executable(freedv_data_tx freedv_data_tx.c)
-target_link_libraries(freedv_data_tx codec2)
+    add_executable(freedv_data_tx freedv_data_tx.c)
+    target_link_libraries(freedv_data_tx codec2)
 
-add_executable(freedv_data_rx freedv_data_rx.c)
-target_link_libraries(freedv_data_rx codec2)
+    add_executable(freedv_data_rx freedv_data_rx.c)
+    target_link_libraries(freedv_data_rx codec2)
 
-add_executable(freedv_mixed_tx freedv_mixed_tx.c)
-target_link_libraries(freedv_mixed_tx codec2)
+    add_executable(freedv_mixed_tx freedv_mixed_tx.c)
+    target_link_libraries(freedv_mixed_tx codec2)
 
-add_executable(freedv_mixed_rx freedv_mixed_rx.c)
-target_link_libraries(freedv_mixed_rx codec2)
+    add_executable(freedv_mixed_rx freedv_mixed_rx.c)
+    target_link_libraries(freedv_mixed_rx codec2)
 
-add_executable(fsk_mod fsk_mod.c)
-target_link_libraries(fsk_mod codec2)
+    add_executable(fsk_mod fsk_mod.c)
+    target_link_libraries(fsk_mod codec2)
 
-add_executable(fsk_mod_ext_vco fsk_mod_ext_vco.c)
-target_link_libraries(fsk_mod_ext_vco m)
+    add_executable(fsk_mod_ext_vco fsk_mod_ext_vco.c)
+    target_link_libraries(fsk_mod_ext_vco m)
 
-add_executable(fsk_demod fsk_demod.c modem_probe.c octave.c)
-target_link_libraries(fsk_demod codec2)
+    add_executable(fsk_demod fsk_demod.c modem_probe.c octave.c)
+    target_link_libraries(fsk_demod codec2)
 
-add_executable(fsk_get_test_bits fsk_get_test_bits.c)
-target_link_libraries(fsk_get_test_bits)
+    add_executable(fsk_get_test_bits fsk_get_test_bits.c)
+    target_link_libraries(fsk_get_test_bits)
 
-add_executable(fsk_put_test_bits fsk_put_test_bits.c)
-target_link_libraries(fsk_put_test_bits codec2)
+    add_executable(fsk_put_test_bits fsk_put_test_bits.c)
+    target_link_libraries(fsk_put_test_bits codec2)
 
-add_executable(framer framer.c)
-target_link_libraries(framer)
+    add_executable(framer framer.c)
+    target_link_libraries(framer)
 
-add_executable(deframer deframer.c)
-target_link_libraries(deframer)
+    add_executable(deframer deframer.c)
+    target_link_libraries(deframer)
 
-add_executable(fm_demod fm_demod.c fm.c)
-target_link_libraries(fm_demod m)
+    add_executable(fm_demod fm_demod.c fm.c)
+    target_link_libraries(fm_demod m)
 
-add_executable(cohpsk_mod cohpsk_mod.c)
-target_link_libraries(cohpsk_mod codec2)
+    add_executable(cohpsk_mod cohpsk_mod.c)
+    target_link_libraries(cohpsk_mod codec2)
 
-add_executable(ofdm_get_test_bits ofdm_get_test_bits.c)
-target_link_libraries(ofdm_get_test_bits codec2)
+    add_executable(ofdm_get_test_bits ofdm_get_test_bits.c)
+    target_link_libraries(ofdm_get_test_bits codec2)
 
-add_executable(ofdm_put_test_bits ofdm_put_test_bits.c)
-target_link_libraries(ofdm_put_test_bits codec2)
+    add_executable(ofdm_put_test_bits ofdm_put_test_bits.c)
+    target_link_libraries(ofdm_put_test_bits codec2)
 
-add_executable(ofdm_mod ofdm_mod.c)
-target_link_libraries(ofdm_mod codec2)
+    add_executable(ofdm_mod ofdm_mod.c)
+    target_link_libraries(ofdm_mod codec2)
 
-add_executable(ofdm_demod ofdm_demod.c octave.c)
-target_link_libraries(ofdm_demod codec2)
+    add_executable(ofdm_demod ofdm_demod.c octave.c)
+    target_link_libraries(ofdm_demod codec2)
 
-add_executable(fmfsk_mod fmfsk_mod.c)
-target_link_libraries(fmfsk_mod codec2)
+    add_executable(fmfsk_mod fmfsk_mod.c)
+    target_link_libraries(fmfsk_mod codec2)
 
-add_executable(fmfsk_demod fmfsk_demod.c modem_probe.c octave.c)
-target_link_libraries(fmfsk_demod codec2)
+    add_executable(fmfsk_demod fmfsk_demod.c modem_probe.c octave.c)
+    target_link_libraries(fmfsk_demod codec2)
 
-add_executable(vhf_deframe_c2 vhf_deframe_c2.c)
-target_link_libraries(vhf_deframe_c2  codec2)
+    add_executable(vhf_deframe_c2 vhf_deframe_c2.c)
+    target_link_libraries(vhf_deframe_c2  codec2)
 
-add_executable(vhf_frame_c2 vhf_frame_c2.c)
-target_link_libraries(vhf_frame_c2  codec2)
+    add_executable(vhf_frame_c2 vhf_frame_c2.c)
+    target_link_libraries(vhf_frame_c2  codec2)
 
-add_executable(cohpsk_demod cohpsk_demod.c octave.c)
-target_link_libraries(cohpsk_demod codec2)
+    add_executable(cohpsk_demod cohpsk_demod.c octave.c)
+    target_link_libraries(cohpsk_demod codec2)
 
-add_executable(cohpsk_get_test_bits cohpsk_get_test_bits.c)
-target_link_libraries(cohpsk_get_test_bits codec2)
+    add_executable(cohpsk_get_test_bits cohpsk_get_test_bits.c)
+    target_link_libraries(cohpsk_get_test_bits codec2)
 
-add_executable(cohpsk_put_test_bits cohpsk_put_test_bits.c octave.c)
-target_link_libraries(cohpsk_put_test_bits codec2)
+    add_executable(cohpsk_put_test_bits cohpsk_put_test_bits.c octave.c)
+    target_link_libraries(cohpsk_put_test_bits codec2)
 
-add_executable(ch ch.c)
-target_link_libraries(ch codec2)
+    add_executable(ch ch.c)
+    target_link_libraries(ch codec2)
 
-add_executable(tollr tollr.c)
+    add_executable(tollr tollr.c)
 
-add_executable(ldpc_noise ldpc_noise.c)
-target_link_libraries(ldpc_noise m)
+    add_executable(ldpc_noise ldpc_noise.c)
+    target_link_libraries(ldpc_noise m)
 
-add_executable(ldpc_enc ldpc_enc.c)
-target_link_libraries(ldpc_enc codec2)
+    add_executable(ldpc_enc ldpc_enc.c)
+    target_link_libraries(ldpc_enc codec2)
 
-add_executable(ldpc_dec ldpc_dec.c)
-target_link_libraries(ldpc_dec codec2)
+    add_executable(ldpc_dec ldpc_dec.c)
+    target_link_libraries(ldpc_dec codec2)
 
 endif(BUILD_EXECUTABLES)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -273,6 +273,7 @@ export(TARGETS codec2
     FILE ${CMAKE_BINARY_DIR}/codec2.cmake
 )
 
+if(BUILD_EXECUTABLES)
 add_executable(c2enc c2enc.c)
 target_link_libraries(c2enc codec2)
 
@@ -391,6 +392,8 @@ target_link_libraries(ldpc_enc codec2)
 
 add_executable(ldpc_dec ldpc_dec.c)
 target_link_libraries(ldpc_dec codec2)
+
+endif(BUILD_EXECUTABLES)
 
 install(TARGETS codec2 EXPORT codec2-config
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib


### PR DESCRIPTION
Adds a cmake option called `BUILD_EXECUTABLES` which is `ON` by defualt. If this option is set to `OFF`, all of the `add_executable()` calls are skipped.

This Fixes Issue #383.