### PR TITLE
Ensure result is initialized in ofdm_complex_dot_product().

### DIFF
--- a/src/ofdm.c
+++ b/src/ofdm.c
@@ -695,7 +695,7 @@ typedef float float4 __attribute__ ((vector_size (16)));
 
 static complex float ofdm_complex_dot_product(complex float *left, complex float *right, int numSamples)
 {
-    complex float result;
+    complex float result = 0;
 
 #if USE_VECTOR_OPS
     float *leftPtr = (float*)left;


### PR DESCRIPTION
Resolves #387 by setting `result` to 0 when vector ops and `EMBEDDED` are not enabled.