### PR TITLE
Remove GNU99 check for Win32 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_custom_target(dist
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-strict-overflow")
 
 # Check for what C standard is supported.
+if(NOT WIN32)
 include(CheckCCompilerFlag)
 CHECK_C_COMPILER_FLAG("-std=gnu11" COMPILER_SUPPORTS_GNU11)
 CHECK_C_COMPILER_FLAG("-std=gnu99" COMPILER_SUPPORTS_GNU99)
@@ -94,6 +95,7 @@ elseif(COMPILER_SUPPORTS_GNU99)
 else()
    message(SEND_ERROR "Compiler doesn't seem to support at least gnu99, might cause problems" )
 endif()
+endif(NOT WIN32)
 
 # -fPIC is implied on MinGW...
 if((NOT WIN32) AND (NOT MICROCONTROLLER_BUILD))


### PR DESCRIPTION
While building with LLVM based MinGW on macOS, I ended up running into the following error during codec2's CMake run:

```
mooneer@macaron build_windows % cmake -DCMAKE_TOOLCHAIN_FILE=~/freedv-gui/cross-compile/freedv-mingw-llvm-x86_64.cmake ..
-- The C compiler identification is Clang 15.0.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Users/mooneer/Downloads/llvm-mingw-20220906-ucrt-macos-universal/bin/x86_64-w64-mingw32-clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found Git: /opt/local/bin/git (found version "2.39.0") 
-- Codec2 current git hash: f68a2fe4
-- Performing Test COMPILER_SUPPORTS_GNU11
-- Performing Test COMPILER_SUPPORTS_GNU11 - Failed
-- Performing Test COMPILER_SUPPORTS_GNU99
-- Performing Test COMPILER_SUPPORTS_GNU99 - Failed
CMake Error at CMakeLists.txt:95 (message):
  Compiler doesn't seem to support at least gnu99, might cause problems


-- System is MinGW.
-- Looking for include file stdlib.h
-- Looking for include file stdlib.h - found
-- Looking for include file string.h
-- Looking for include file string.h - found
-- Looking for __GNU_LIBRARY__
-- Looking for __GNU_LIBRARY__ - not found
-- Looking for _GNU_SOURCE
-- Looking for _GNU_SOURCE - not found
-- Looking for floor
-- Looking for floor - found
-- Looking for ceil
-- Looking for ceil - found
-- Looking for pow
-- Looking for pow - found
-- Looking for sqrt
-- Looking for sqrt - found
-- Looking for sin
-- Looking for sin - found
-- Looking for cos
-- Looking for cos - found
-- Looking for atan2
-- Looking for atan2 - found
-- Looking for log10
-- Looking for log10 - found
-- Looking for round
-- Looking for round - found
-- Looking for getopt
-- Looking for getopt - found
-- codec2 version: 1.1.0
-- Build type is: Debug
-- Compiler Flags: -gcodeview -Wall -Wno-strict-overflow-g -O2 -DDUMP
-- Libraries linked: 
-- Compilation date = XX2023-06-10XX
-- Configuring incomplete, errors occurred!
```

This PR suppresses this check for Win32 builds as it's assumed that the necessary C language support is there (plus that codec2 builds with no problems).