### PR TITLE
add M_PI to defines.h

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -42,6 +42,9 @@
 #ifndef PI
 #define PI 3.141592654 /* mathematical constant                */
 #endif
+#ifndef M_PI
+#define M_PI 3.14159265358979323846f
+#endif
 #define TWO_PI 6.283185307 /* mathematical constant                */
 #define MAX_STR 2048       /* maximum string size                  */
 


### PR DESCRIPTION
This is a patch to get the code to compile with toolchains that don't have M_PI defined.

At the moment, the Codec2 source code has at least three fallback pi values should the define not already exist in the toolchain:

PI (defined in ./src/defines.h)
M_PI (defined in ./src/ofdm_internal.h)
M_PI (in source code not dependent on ./src/ofdm_internal.h)

The third fails when M_PI is not defined, and perhaps a related scenario was previously identified and partially patched with ./src/ofdm_internal.h

The approach of this PR is to duplicate the existing M_PI definition in ./src/ofdm_internal.h in ./src/defines.h

The temptation would be to have ./src/ofdm_internal.h obtain a shared M_PI definition in ./src/defines.h, but ./src/defines.h also has some unrelated-to-ofdm codec2 internal struct definitions, etc.

There is also the potential to define PI as M_PI, or standardize on M_PI in lieu of PI, but the exact reasons for code use of PI vs M_PI are opaque to me.

Thanks.