### PR TITLE
Fix issue with squelch remaining enabled on 1600 mode even when disabled.

### DIFF
--- a/src/freedv_1600.c
+++ b/src/freedv_1600.c
@@ -28,7 +28,8 @@
 
 void freedv_1600_open(struct freedv *f) {
   f->snr_squelch_thresh = 2.0;
-  f->squelch_en = true;
+  f->squelch_en = false;
+  f->passthrough_gain = 0.25;
   f->tx_sync_bit = 0;
   int Nc = 16;
   f->fdmdv = fdmdv_create(Nc);


### PR DESCRIPTION
On freedv-gui, Rick WA6III discovered an issue on his Windows machine where when squelch was turned off, there'd be no analog audio coming through his speakers. I worked with him over Zoom and determined that when 1600 mode's selected (with multiple receive turned off), squelch would effectively stay turned on. As his system was defaulting to 1600, that's why he was experiencing the issue.

As a workaround, https://github.com/drowe67/freedv-gui/pull/544 was created on the freedv-gui side. This causes the multiple receive logic to default to the current transmit mode if there's no sync, making the no sync behavior more deterministic and thus making it less likely to run into this issue.

Some additional testing was done on the codec2 side to find the root cause. The following commands were run to determine the difference between 700D and 1600 in terms of squelch behavior:

```
mooneer@macaron src % sox ../../wav/ve9qrp.wav -t raw -e signed-integer -r 8000 -c 1 - | ./freedv_rx 700D - result.raw
frames decoded: 708  output speech samples: 906240
mooneer@macaron src % sox ../../wav/ve9qrp.wav -t raw -e signed-integer -r 8000 -c 1 - | ./freedv_rx 1600 - result.raw
frames decoded: 6090  output speech samples: 320
mooneer@macaron src %
```

(Note the drastically reduced number of samples when using the 1600 decoder despite squelch being turned off.)

In `freedv_1600.c`, I discovered that `f->squelch_en` was defaulting to true, which was different than all other FreeDV modes. Changing this to false resulted in a "output speech samples" figure more in line with the size of the test wav file:

```
mooneer@macaron src % sox ../../wav/ve9qrp.wav -t raw -e signed-integer -r 8000 -c 1 - | ./freedv_rx 1600 - result.raw             
frames decoded: 6090  output speech samples: 907480
mooneer@macaron src %
```

However, importing result.raw into Audacity still produced audio that was similar to what Rick and I observed. Further investigation showed that `f->passthrough_gain` needed to be initialized as well as it was being zeroed out otherwise, causing no audio to be passed through by `freedv_bits_to_speech()`. More specifically, 1600 mode was executing this logic when there's no sync:

```
        /* Speech and modem rates might be different */
        int rate_factor = f->modem_sample_rate / f->speech_sample_rate;
        nout = f->nin_prev / rate_factor;
        for (int i = 0; i < nout; i++)
          speech_out[i] = f->passthrough_gain * demod_in[i * rate_factor];
```