### PR TITLE
Fix issue preventing documentation ctest from executing in GitHub environment.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Run ctests
       working-directory: ${{github.workspace}}/build_linux
       shell: bash
-      run: ctest --output-on-failure -E test_codec2_doc
+      run: ctest --output-on-failure
 
     - name: Test library installation
       working-directory: ${{github.workspace}}/build_linux

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
       shell: bash
       run: |
            sudo apt-get update
-           sudo apt-get install octave octave-common octave-signal liboctave-dev gnuplot sox p7zip-full python3-numpy valgrind clang-format texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra
+           sudo apt-get install octave octave-common octave-signal liboctave-dev gnuplot sox p7zip-full python3-numpy valgrind clang-format texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra texlive-science texmaker texlive-bibtex-extra
    
     - name: Create Build Directory
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
       shell: bash
       run: |
            sudo apt-get update
-           sudo apt-get install octave octave-common octave-signal liboctave-dev gnuplot sox p7zip-full python3-numpy valgrind clang-format
+           sudo apt-get install octave octave-common octave-signal liboctave-dev gnuplot sox p7zip-full python3-numpy valgrind clang-format texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra
    
     - name: Create Build Directory
       shell: bash

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,10 +20,10 @@ PATH := $(PATH):$(CODEC2_BINARY)/src
 PLOT_FILES := hts2a_37_sn.tex hts2a_37_sw.tex hts2a_37_lpc_lsp.tex hts2a_37_lpc_pf.tex
 
 $(DOCNAME).pdf: $(PLOT_FILES) $(DOCNAME).tex $(DOCNAME)_refs.bib
-	pdflatex -file-line-error -jobname=$(JOBNAME) $(DOCNAME).tex 
+	pdflatex -shell-escape -file-line-error -jobname=$(JOBNAME) $(DOCNAME).tex 
 	bibtex   $(JOBNAME).aux
-	pdflatex -file-line-error -jobname=$(JOBNAME) $(DOCNAME).tex
-	pdflatex -file-line-error -jobname=$(JOBNAME) $(DOCNAME).tex
+	pdflatex -shell-escape -file-line-error -jobname=$(JOBNAME) $(DOCNAME).tex
+	pdflatex -shell-escape -file-line-error -jobname=$(JOBNAME) $(DOCNAME).tex
 
 $(PLOT_FILES):
 	echo $(PATH)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,10 +20,10 @@ PATH := $(PATH):$(CODEC2_BINARY)/src
 PLOT_FILES := hts2a_37_sn.tex hts2a_37_sw.tex hts2a_37_lpc_lsp.tex hts2a_37_lpc_pf.tex
 
 $(DOCNAME).pdf: $(PLOT_FILES) $(DOCNAME).tex $(DOCNAME)_refs.bib
-	pdflatex -jobname=$(JOBNAME) $(DOCNAME).tex 
+	pdflatex -file-line-error -jobname=$(JOBNAME) $(DOCNAME).tex 
 	bibtex   $(JOBNAME).aux
-	pdflatex -jobname=$(JOBNAME) $(DOCNAME).tex
-	pdflatex -jobname=$(JOBNAME) $(DOCNAME).tex
+	pdflatex -file-line-error -jobname=$(JOBNAME) $(DOCNAME).tex
+	pdflatex -file-line-error -jobname=$(JOBNAME) $(DOCNAME).tex
 
 $(PLOT_FILES):
 	echo $(PATH)

--- a/doc/codec2.tex
+++ b/doc/codec2.tex
@@ -53,7 +53,7 @@ pinstyle/.style = {pin edge={to-,thin,black}}
 	\draw (#1,#2-0.25) -- (#1,#2+0.25);
 }
 
-\maketitle
+%\maketitle
 
 \section{Introduction}
 

--- a/doc/codec2.tex
+++ b/doc/codec2.tex
@@ -8,6 +8,7 @@
 \usepackage{xstring}
 \usepackage{catchfile}
 \usepackage{siunitx}
+\usepackage{array}
 
 \CatchFileDef{\headfull}{../.git/HEAD}{}
 \StrGobbleRight{\headfull}{1}[\head]

--- a/doc/codec2.tex
+++ b/doc/codec2.tex
@@ -8,7 +8,6 @@
 \usepackage{xstring}
 \usepackage{catchfile}
 \usepackage{siunitx}
-\usepackage{array}
 
 \CatchFileDef{\headfull}{../.git/HEAD}{}
 \StrGobbleRight{\headfull}{1}[\head]

--- a/doc/codec2.tex
+++ b/doc/codec2.tex
@@ -9,14 +9,14 @@
 \usepackage{catchfile}
 \usepackage{siunitx}
 
-\CatchFileDef{\headfull}{../.git/HEAD}{}
-\StrGobbleRight{\headfull}{1}[\head]
-\StrBehind[2]{\head}{/}[\branch]
-\IfFileExists{../.git/refs/heads/\branch}{%
-    \CatchFileDef{\commit}{../.git/refs/heads/\branch}{}}{%
-    \newcommand{\commit}{\dots~(in \emph{packed-refs})}}
 \newcommand{\gitrevision}{%
-  \StrLeft{\commit}{7}%
+  \immediate\write18{git log -n1 --oneline | awk '{print $1;}' > gitrevision.txt}
+  \input{gitrevision.txt}
+}
+
+\newcommand{\branch}{%
+  \immediate\write18{git branch --show-current > gitbranch.txt}
+  \input{gitbranch.txt}
 }
 
 \title{Codec 2}
@@ -53,7 +53,7 @@ pinstyle/.style = {pin edge={to-,thin,black}}
 	\draw (#1,#2-0.25) -- (#1,#2+0.25);
 }
 
-%\maketitle
+\maketitle
 
 \section{Introduction}
 


### PR DESCRIPTION
The TeX file was attempting to read internal Git files to obtain branch and revision info, which works locally but not in the GitHub environment. This PR calls the various git commands to get that info instead.