### PR TITLE
Fix libasan related crashes

### DIFF
--- a/src/c2sim.c
+++ b/src/c2sim.c
@@ -1129,6 +1129,12 @@ int main(int argc, char *argv[]) {
   if (fbands != NULL) fclose(fbands);
   if (frateKWov != NULL) fclose(frateKWov);
 
+  codec2_fft_free(fft_fwd_cfg);
+  codec2_fftr_free(fftr_fwd_cfg);
+  codec2_fftr_free(fftr_inv_cfg);
+  codec2_fft_free(phase_fft_fwd_cfg);
+  codec2_fft_free(phase_fft_inv_cfg);
+
   return 0;
 }
 

--- a/src/ch.c
+++ b/src/ch.c
@@ -212,6 +212,7 @@ int main(int argc, char *argv[]) {
         ctest = 1;
         break;
       case 'u':
+        if (fading_dir) free(fading_dir);
         fading_dir = strdup(optarg);
         break;
       case 'h':
@@ -519,6 +520,7 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "ch: WARNING output clipping\n");
 
   if (ffading != NULL) fclose(ffading);
+  if (fading_dir) free(fading_dir);
   if (ch_fdm_delay != NULL) FREE(ch_fdm_delay);
   if (ctest) {
     /* special ctest mode: check CPAPR is around 0dB */

--- a/src/cohpsk_put_test_bits.c
+++ b/src/cohpsk_put_test_bits.c
@@ -65,11 +65,13 @@ int main(int argc, char *argv[]) {
   }
 
   coh = cohpsk_create();
+  assert(coh != NULL);
 
   foct = NULL;
   logframes = 0;
   if (argc == 3) {
     if ((foct = fopen(argv[2], "wt")) == NULL) {
+      cohpsk_destroy(coh);
       fprintf(stderr, "Error opening output Octave file: %s: %s.\n", argv[2],
               strerror(errno));
       exit(1);
@@ -101,6 +103,7 @@ int main(int argc, char *argv[]) {
   }
 
   fclose(fin);
+  cohpsk_destroy(coh);
   float ber = (float)nerrors / nbits;
   fprintf(stderr, "BER: %4.3f Nbits: %d Nerrors: %d\n", ber, nbits, nerrors);
 

--- a/src/fdmdv_demod.c
+++ b/src/fdmdv_demod.c
@@ -247,8 +247,12 @@ int main(int argc, char *argv[]) {
 
   fclose(fin);
   fclose(fout);
+  FREE(rx_bits);
+  FREE(codec_bits);
   FREE(rx_fdm_log);
   FREE(rx_spec_log);
+  FREE(rx_symbols_log);
+  modem_stats_close(&stats);
   fdmdv_destroy(fdmdv);
 
   if (packed_bits != NULL) FREE(packed_bits);

--- a/src/fdmdv_put_test_bits.c
+++ b/src/fdmdv_put_test_bits.c
@@ -155,6 +155,7 @@ int main(int argc, char *argv[]) {
   }
 
   fclose(fin);
+  free(rx_bits);
   free(error_pattern);
   fdmdv_destroy(fdmdv);
 

--- a/src/fmfsk.c
+++ b/src/fmfsk.c
@@ -93,6 +93,7 @@ struct FMFSK *fmfsk_create(int Fs, int Rb) {
  * Destroys an fmfsk modem and deallocates memory
  */
 void fmfsk_destroy(struct FMFSK *fmfsk) {
+  free(fmfsk->stats);
   free(fmfsk->oldsamps);
   free(fmfsk);
 }

--- a/src/freedv_2020.c
+++ b/src/freedv_2020.c
@@ -276,8 +276,8 @@ int freedv_comprx_2020(struct freedv *f, COMP demod_in[]) {
     gp_deinterleave_float(codeword_amps_de, codeword_amps,
                           coded_syms_per_frame);
 
-    float llr[coded_bits_per_frame];
-    uint8_t out_char[coded_bits_per_frame];
+    float llr[ldpc->CodeLength * 2];
+    uint8_t out_char[ldpc->CodeLength * 2];
 
     if (f->test_frames) {
       Nerrs_raw =

--- a/src/freedv_700.c
+++ b/src/freedv_700.c
@@ -493,8 +493,8 @@ int freedv_comp_short_rx_ofdm(struct freedv *f, void *demod_in_8kHz,
       gp_deinterleave_float(payload_amps_de, payload_amps,
                             Npayloadsymsperpacket);
 
-      float llr[Npayloadbitsperpacket];
-      uint8_t decoded_codeword[Npayloadbitsperpacket];
+      float llr[ldpc->CodeLength * 2];
+      uint8_t decoded_codeword[ldpc->CodeLength * 2];
       symbols_to_llrs(llr, payload_syms_de, payload_amps_de, EsNo,
                       ofdm->mean_amp, Npayloadsymsperpacket);
       ldpc_decode_frame(ldpc, &parityCheckCount, &iter, decoded_codeword, llr);

--- a/src/freedv_api.c
+++ b/src/freedv_api.c
@@ -214,11 +214,13 @@ void freedv_close(struct freedv *freedv) {
 
   if (FDV_MODE_ACTIVE(FREEDV_MODE_2400A, freedv->mode) ||
       FDV_MODE_ACTIVE(FREEDV_MODE_800XA, freedv->mode)) {
+    FREE(freedv->tx_bits);
     fsk_destroy(freedv->fsk);
     fvhff_destroy_deframer(freedv->deframer);
   }
 
   if (FDV_MODE_ACTIVE(FREEDV_MODE_2400B, freedv->mode)) {
+    FREE(freedv->tx_bits);
     fmfsk_destroy(freedv->fmfsk);
     fvhff_destroy_deframer(freedv->deframer);
   }

--- a/src/freedv_fsk.c
+++ b/src/freedv_fsk.c
@@ -123,7 +123,12 @@ void freedv_800xa_open(struct freedv *f) {
 
   f->bits_per_codec_frame = codec2_bits_per_frame(f->codec2);
   f->bits_per_modem_frame = f->n_codec_frames * f->bits_per_codec_frame;
-  int n_packed_bytes = ceil((f->bits_per_modem_frame + 7.0) / 8.0) + 1;  /* ~3.5 bits per frame, which needs to be rounded up to 4. */
+
+  /*
+   * ~3.5 bits per frame, which needs to be rounded up to 4 because computers
+   * can't handle half bytes.
+   */
+  int n_packed_bytes = ceil((f->bits_per_modem_frame + 7.0) / 8.0) + 1;
   if (n_packed_bytes < 8) n_packed_bytes = 8;
   f->tx_payload_bits = MALLOC(n_packed_bytes);
   assert(f->tx_payload_bits != NULL);

--- a/src/freedv_fsk.c
+++ b/src/freedv_fsk.c
@@ -91,7 +91,7 @@ void freedv_2400b_open(struct freedv *f) {
   f->n_codec_frames = 1;
   f->bits_per_codec_frame = codec2_bits_per_frame(f->codec2);
   f->bits_per_modem_frame = f->bits_per_codec_frame;
-  int n_packed_bytes = (f->bits_per_modem_frame + 7) / 8;
+  int n_packed_bytes = (f->bits_per_modem_frame + 7) / 8 + 1;
   f->tx_payload_bits = MALLOC(n_packed_bytes);
   assert(f->tx_payload_bits != NULL);
   f->rx_payload_bits = MALLOC(n_packed_bytes);
@@ -123,7 +123,7 @@ void freedv_800xa_open(struct freedv *f) {
 
   f->bits_per_codec_frame = codec2_bits_per_frame(f->codec2);
   f->bits_per_modem_frame = f->n_codec_frames * f->bits_per_codec_frame;
-  int n_packed_bytes = (f->bits_per_modem_frame + 7.0) / 8.0 + 0.5;
+  int n_packed_bytes = (f->bits_per_modem_frame + 7) / 8;
   f->tx_payload_bits = MALLOC(n_packed_bytes);
   assert(f->tx_payload_bits != NULL);
   f->rx_payload_bits = MALLOC(n_packed_bytes);

--- a/src/freedv_fsk.c
+++ b/src/freedv_fsk.c
@@ -123,7 +123,7 @@ void freedv_800xa_open(struct freedv *f) {
 
   f->bits_per_codec_frame = codec2_bits_per_frame(f->codec2);
   f->bits_per_modem_frame = f->n_codec_frames * f->bits_per_codec_frame;
-  int n_packed_bytes = (f->bits_per_modem_frame + 7) / 8;
+  int n_packed_bytes = (f->bits_per_modem_frame + 7.0) / 8.0 + 0.5;
   f->tx_payload_bits = MALLOC(n_packed_bytes);
   assert(f->tx_payload_bits != NULL);
   f->rx_payload_bits = MALLOC(n_packed_bytes);

--- a/src/freedv_fsk.c
+++ b/src/freedv_fsk.c
@@ -59,7 +59,7 @@ void freedv_2400a_open(struct freedv *f) {
   f->n_codec_frames = 1;
   f->bits_per_codec_frame = codec2_bits_per_frame(f->codec2);
   f->bits_per_modem_frame = f->bits_per_codec_frame;
-  int n_packed_bytes = (f->bits_per_modem_frame + 7) / 8;
+  int n_packed_bytes = ceil((f->bits_per_modem_frame + 7.0) / 8.0) + 1;
   f->tx_payload_bits = MALLOC(n_packed_bytes);
   assert(f->tx_payload_bits != NULL);
   f->rx_payload_bits = MALLOC(n_packed_bytes);
@@ -123,7 +123,7 @@ void freedv_800xa_open(struct freedv *f) {
 
   f->bits_per_codec_frame = codec2_bits_per_frame(f->codec2);
   f->bits_per_modem_frame = f->n_codec_frames * f->bits_per_codec_frame;
-  int n_packed_bytes = (f->bits_per_modem_frame + 7) / 8;
+  int n_packed_bytes = ceil((f->bits_per_modem_frame + 7.0) / 8.0) + 1;
   f->tx_payload_bits = MALLOC(n_packed_bytes);
   assert(f->tx_payload_bits != NULL);
   f->rx_payload_bits = MALLOC(n_packed_bytes);

--- a/src/freedv_fsk.c
+++ b/src/freedv_fsk.c
@@ -123,7 +123,8 @@ void freedv_800xa_open(struct freedv *f) {
 
   f->bits_per_codec_frame = codec2_bits_per_frame(f->codec2);
   f->bits_per_modem_frame = f->n_codec_frames * f->bits_per_codec_frame;
-  int n_packed_bytes = ceil((f->bits_per_modem_frame + 7.0) / 8.0) + 1;
+  int n_packed_bytes = ceil((f->bits_per_modem_frame + 7.0) / 8.0) + 1;  /* ~3.5 bits per frame, which needs to be rounded up to 4. */
+  if (n_packed_bytes < 8) n_packed_bytes = 8;
   f->tx_payload_bits = MALLOC(n_packed_bytes);
   assert(f->tx_payload_bits != NULL);
   f->rx_payload_bits = MALLOC(n_packed_bytes);

--- a/src/freedv_rx.c
+++ b/src/freedv_rx.c
@@ -306,6 +306,7 @@ int main(int argc, char *argv[]) {
 
   /* finish up with some stats */
 
+  int rc = 0;
   if (freedv_get_test_frames(freedv)) {
     int Tbits = freedv_get_total_bits(freedv);
     int Terrs = freedv_get_total_bit_errors(freedv);
@@ -327,9 +328,9 @@ int main(int argc, char *argv[]) {
 
       /* set return code for Ctest */
       if ((uncoded_ber < 0.1f) && (coded_ber < 0.01f))
-        return 0;
+        rc = 0;
       else
-        return 1;
+        rc = 1;
     }
   }
 
@@ -339,5 +340,5 @@ int main(int argc, char *argv[]) {
 
   freedv_close(freedv);
 
-  return 0;
+  return rc;
 }

--- a/src/freedv_tx.c
+++ b/src/freedv_tx.c
@@ -57,6 +57,7 @@ void on_reliable_text_rx(reliable_text_t rt, const char *txt_ptr, int length,
 }
 
 int main(int argc, char *argv[]) {
+  struct my_callback_state my_cb_state;
   FILE *fin, *fout;
   struct freedv *freedv;
   int mode;
@@ -184,7 +185,6 @@ int main(int argc, char *argv[]) {
                                   on_reliable_text_rx, NULL);
   } else {
     /* set up callback for txt msg chars */
-    struct my_callback_state my_cb_state;
     sprintf(my_cb_state.tx_str, "cq cq cq hello world\r");
     my_cb_state.ptx_str = my_cb_state.tx_str;
     my_cb_state.calls = 0;

--- a/src/freedv_vhf_framing.c
+++ b/src/freedv_vhf_framing.c
@@ -391,6 +391,7 @@ int fvhff_get_varicode_size(struct freedv_vhf_deframer *def) {
 void fvhff_destroy_deframer(struct freedv_vhf_deframer *def) {
   freedv_data_channel_destroy(def->fdc);
   free(def->bits);
+  free(def->invbits);
   free(def);
 }
 

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -413,8 +413,8 @@ int main(int argc, char *argv[]) {
   if (verbose == 2) fprintf(stderr, "Warning EsNo: %f hard coded\n", EsNo);
 
   /* More logging */
-  COMP payload_syms_log[NFRAMES][Npayloadsymsperpacket];
-  float payload_amps_log[NFRAMES][Npayloadsymsperpacket];
+  COMP payload_syms_log[NFRAMES][Npayloadsymsperframe];
+  float payload_amps_log[NFRAMES][Npayloadsymsperframe];
 
   for (i = 0; i < NFRAMES; i++) {
     for (j = 0; j < Npayloadsymsperframe; j++) {

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -489,7 +489,7 @@ int main(int argc, char *argv[]) {
                                 Npayloadsymsperpacket);
 
           float llr[Npayloadbitsperpacket];
-          uint8_t out_char[Npayloadbitsperpacket];
+          uint8_t out_char[ldpc.CodeLength];
 
           if (testframes == true) {
             Nerrs_raw =

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -488,8 +488,8 @@ int main(int argc, char *argv[]) {
           gp_deinterleave_float(payload_amps_de, payload_amps,
                                 Npayloadsymsperpacket);
 
-          float llr[Npayloadbitsperpacket];
-          uint8_t out_char[ldpc.CodeLength];
+          float llr[ldpc.CodeLength * 2];
+          uint8_t out_char[ldpc.CodeLength * 2];
 
           if (testframes == true) {
             Nerrs_raw =

--- a/src/ofdm_demod.c
+++ b/src/ofdm_demod.c
@@ -385,7 +385,7 @@ int main(int argc, char *argv[]) {
 
   short rx_scaled[Nmaxsamperframe];
   int rx_bits[Nbitsperframe];
-  uint8_t rx_bits_char[Nbitsperframe];
+  uint8_t rx_bits_char[Npayloadsymsperpacket * 2];
   uint8_t rx_uw[ofdm_nuwbits];
   short txt_bits[ofdm_ntxtbits];
 

--- a/unittest/tcohpsk.c
+++ b/unittest/tcohpsk.c
@@ -71,8 +71,8 @@ int main(int argc, char *argv[]) {
   int tx_bits_log[COHPSK_BITS_PER_FRAME * FRAMES];
   COMP tx_symb_log[NSYMROWPILOT * FRAMES][COHPSK_NC * COHPSK_ND];
   COMP tx_fdm_frame_log[COHPSK_M * NSYMROWPILOT * FRAMES];
-  COMP ch_fdm_frame_log[COHPSK_M * NSYMROWPILOT * FRAMES];
-  COMP ch_fdm_frame_log_out[(COHPSK_M * NSYMROWPILOT + 1) * FRAMES];
+  COMP ch_fdm_frame_log[COHPSK_M * NSYMROWPILOT * FRAMESL];
+  COMP ch_fdm_frame_log_out[(COHPSK_M * NSYMROWPILOT + 1) * FRAMESL];
   // COMP           rx_fdm_frame_bb_log[M*NSYMROWPILOT*FRAMES];
   // COMP           ch_symb_log[NSYMROWPILOT*FRAMES][COHPSK_NC*COHPSK_ND];
   COMP ct_symb_ff_log[NSYMROWPILOT * FRAMES][COHPSK_NC * COHPSK_ND];
@@ -317,6 +317,11 @@ int main(int argc, char *argv[]) {
 #ifdef XX
 #endif
   fclose(fout);
+
+  free(coh->rx_baseband_log);
+  free(coh->rx_filt_log);
+  free(coh->ch_symb_log);
+  free(coh->rx_timing_log);
 
   cohpsk_destroy(coh);
 

--- a/unittest/tfreedv_2400A_rawdata.c
+++ b/unittest/tfreedv_2400A_rawdata.c
@@ -100,6 +100,9 @@ int main(int argc, char **argv) {
       }
     }
   }
+
+  freedv_close(f);
+
   if (!frames) {
     printf("Did not decode any frames successfully\n");
     goto fail;

--- a/unittest/tfreedv_2400B_rawdata.c
+++ b/unittest/tfreedv_2400B_rawdata.c
@@ -100,6 +100,9 @@ int main(int argc, char **argv) {
       }
     }
   }
+
+  freedv_close(f);
+
   if (!frames) {
     printf("Did not decode any frames successfully\n");
     goto fail;

--- a/unittest/tfreedv_800XA_rawdata.c
+++ b/unittest/tfreedv_800XA_rawdata.c
@@ -132,6 +132,9 @@ int main(int argc, char **argv) {
       }
     }
   }
+
+  freedv_close(f);
+
   if (!frames) {
     printf("Did not decode any frames successfully\n");
     goto fail;

--- a/unittest/tfreedv_800XA_rawdata.c
+++ b/unittest/tfreedv_800XA_rawdata.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
   unsigned char payload_tx[7] = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde};
 
   printf("freedv_codec_frames_from_rawdata() ");
-  unsigned char codec_frames[8] = {0};
+  unsigned char codec_frames[9] = {0};
   freedv_codec_frames_from_rawdata(f, codec_frames, payload_tx);
   int fails = 0;
   for (i = 0; i < 8; i++) {
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
   printf("Passed\n");
 
   printf("freedv_rawdata_from_codec_frames() ");
-  unsigned char rawdata[7] = {0};
+  unsigned char rawdata[8] = {0};
   freedv_rawdata_from_codec_frames(f, rawdata, payload);
   fails = 0;
   for (i = 0; i < 7; i++) {

--- a/unittest/tnewamp1.c
+++ b/unittest/tnewamp1.c
@@ -287,6 +287,11 @@ int main(int argc, char *argv[]) {
   octave_save_complex(fout, "H_c", (COMP *)H, FRAMES, MAX_AMP, MAX_AMP);
   fclose(fout);
 
+  codec2_fft_free(fft_fwd_cfg);
+  codec2_fft_free(phase_fft_fwd_cfg);
+  codec2_fft_free(phase_fft_inv_cfg);
+  nlp_destroy(nlp_states);
+
   printf(
       "Done! Now run\n  octave:1> "
       "tnewamp1(\"../path/to/build_linux/src/hts1a\", "

--- a/unittest/vq_mbest.c
+++ b/unittest/vq_mbest.c
@@ -221,8 +221,8 @@ void quant_mbest(float vec_out[], int indexes[], float vec_in[], int num_stages,
   float err[k], se1;
   int i, j, s, s1, ind;
 
-  struct MBEST *mbest_stage[num_stages];
-  int index[num_stages];
+  struct MBEST *mbest_stage[MAX_STAGES];
+  int index[MAX_STAGES];
   float target[k];
 
   for (i = 0; i < num_stages; i++) {


### PR DESCRIPTION
This PR fixes the libasan-related crashes per #43. On x86_64, all tests now pass except for `test_demo_700d_python` (likely due to how libasan interacts with Python itself) and `test_clang_format` (Fedora's `clang-format` is apparently a different version than the one in GitHub and throws errors).

EDIT: updated PR to reflect latest state.