### PR TITLE
pkg-config: Fix include dirs in codec2.pc

### DIFF
--- a/codec2.pc.in
+++ b/codec2.pc.in
@@ -1,10 +1,10 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/codec2
+includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: codec2
 Description: A speech codec for 2400 bit/s and below
 Requires: 
 Version: @CODEC2_VERSION@
 Libs: -L${libdir} -lcodec2
-Cflags: -I${includedir} 
+Cflags: -I${includedir} -I${includedir}/codec2


### PR DESCRIPTION
Fixes #48 

Properly define Cflags in pkg-config file. We need the additional path for non-standard installation paths of this library. We do not change the single include path to be compatible with existing application linking against this library