### PR TITLE
rename lpc/lsp functions with codec2 prefix to prevent name clash with libspeex

### DIFF
--- a/src/c2sim.c
+++ b/src/c2sim.c
@@ -737,13 +737,13 @@ int main(int argc, char *argv[]) {
         encode_lsps_scalar(lsp_indexes, lsps, LPC_ORD);
         decode_lsps_scalar(lsps_, lsp_indexes, LPC_ORD);
         bw_expand_lsps(lsps_, LPC_ORD, 50.0, 100.0);
-        lsp_to_lpc(lsps_, ak_, LPC_ORD);
+        codec2_lsp_to_lpc(lsps_, ak_, LPC_ORD);
       }
 
       if (lspd) {
         encode_lspds_scalar(lsp_indexes, lsps, LPC_ORD);
         decode_lspds_scalar(lsps_, lsp_indexes, LPC_ORD);
-        lsp_to_lpc(lsps_, ak_, LPC_ORD);
+        codec2_lsp_to_lpc(lsps_, ak_, LPC_ORD);
       }
 
       if (lspjmv) {
@@ -753,7 +753,7 @@ int main(int argc, char *argv[]) {
           float lsps_bw[LPC_ORD];
           memcpy(lsps_bw, lsps_, sizeof(float) * order);
           bw_expand_lsps(lsps_bw, LPC_ORD, 50.0, 100.0);
-          lsp_to_lpc(lsps_bw, ak_, LPC_ORD);
+          codec2_lsp_to_lpc(lsps_bw, ak_, LPC_ORD);
         }
       }
 
@@ -1021,7 +1021,7 @@ int main(int argc, char *argv[]) {
 
       for (i = 0; i < decimate; i++) {
         if (lpc_model) {
-          lsp_to_lpc(&lsps_dec[i][0], &ak_dec[i][0], order);
+          codec2_lsp_to_lpc(&lsps_dec[i][0], &ak_dec[i][0], order);
           aks_to_M2(fftr_fwd_cfg, &ak_dec[i][0], order, &model_dec[i], e_dec[i],
                     &snr, 1, simlpcpf, lpcpf, 1, LPCPF_BETA, LPCPF_GAMMA, Aw);
           apply_lpc_correction(&model_dec[i]);

--- a/src/codec2.c
+++ b/src/codec2.c
@@ -532,7 +532,7 @@ void codec2_decode_3200(struct CODEC2 *c2, short speech[],
                        LPC_ORD);
 
   for (i = 0; i < 2; i++) {
-    lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD);
+    codec2_lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD);
     aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD, &model[i], e[i], &snr, 0, 0,
               c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
     apply_lpc_correction(&model[i]);
@@ -672,7 +672,7 @@ void codec2_decode_2400(struct CODEC2 *c2, short speech[],
   interpolate_lsp_ver2(&lsps[0][0], c2->prev_lsps_dec, &lsps[1][0], 0.5,
                        LPC_ORD);
   for (i = 0; i < 2; i++) {
-    lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD);
+    codec2_lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD);
     aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD, &model[i], e[i], &snr, 0, 0,
               c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
     apply_lpc_correction(&model[i]);
@@ -865,7 +865,7 @@ void codec2_decode_1600(struct CODEC2 *c2, short speech[],
                          LPC_ORD);
   }
   for (i = 0; i < 4; i++) {
-    lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD);
+    codec2_lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD);
     aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD, &model[i], e[i], &snr, 0, 0,
               c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
     apply_lpc_correction(&model[i]);
@@ -1032,7 +1032,7 @@ void codec2_decode_1400(struct CODEC2 *c2, short speech[],
                          LPC_ORD);
   }
   for (i = 0; i < 4; i++) {
-    lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD);
+    codec2_lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD);
     aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD, &model[i], e[i], &snr, 0, 0,
               c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
     apply_lpc_correction(&model[i]);
@@ -1202,7 +1202,7 @@ void codec2_decode_1300(struct CODEC2 *c2, short speech[],
   /* then recover spectral amplitudes */
 
   for (i = 0; i < 4; i++) {
-    lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD);
+    codec2_lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD);
     aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD, &model[i], e[i], &snr, 0, 0,
               c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
     apply_lpc_correction(&model[i]);
@@ -1390,7 +1390,7 @@ void codec2_decode_1200(struct CODEC2 *c2, short speech[],
                          LPC_ORD);
   }
   for (i = 0; i < 4; i++) {
-    lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD);
+    codec2_lsp_to_lpc(&lsps[i][0], &ak[i][0], LPC_ORD);
     aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD, &model[i], e[i], &snr, 0, 0,
               c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
     apply_lpc_correction(&model[i]);

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -128,7 +128,7 @@ static float cheb_poly_eva(float *coef, float x, int order)
 
 \*---------------------------------------------------------------------------*/
 
-int lpc_to_lsp(float *a, int order, float *freq, int nb, float delta)
+int codec2_lpc_to_lsp(float *a, int order, float *freq, int nb, float delta)
 /*  float *a 		     	lpc coefficients			*/
 /*  int order			order of LPC coefficients (10) 		*/
 /*  float *freq 	      	LSP frequencies in radians      	*/
@@ -253,7 +253,7 @@ int lpc_to_lsp(float *a, int order, float *freq, int nb, float delta)
 
 \*---------------------------------------------------------------------------*/
 
-void lsp_to_lpc(float *lsp, float *ak, int order)
+void codec2_lsp_to_lpc(float *lsp, float *ak, int order)
 /*  float *freq         array of LSP frequencies in radians     	*/
 /*  float *ak 		array of LPC coefficients 			*/
 /*  int order     	order of LPC coefficients 			*/

--- a/src/lsp.h
+++ b/src/lsp.h
@@ -31,7 +31,7 @@
 #ifndef __LSP__
 #define __LSP__
 
-int lpc_to_lsp(float *a, int lpcrdr, float *freq, int nb, float delta);
-void lsp_to_lpc(float *freq, float *ak, int lpcrdr);
+int codec2_lpc_to_lsp(float *a, int lpcrdr, float *freq, int nb, float delta);
+void codec2_lsp_to_lpc(float *freq, float *ak, int lpcrdr);
 
 #endif

--- a/src/quantise.c
+++ b/src/quantise.c
@@ -683,7 +683,7 @@ float speech_to_uq_lsps(float lsp[], float ak[], float Sn[], float w[],
 
   for (i = 0; i <= order; i++) ak[i] *= powf(0.994, (float)i);
 
-  roots = lpc_to_lsp(ak, order, lsp, 5, LSP_DELTA1);
+  roots = codec2_lpc_to_lsp(ak, order, lsp, 5, LSP_DELTA1);
   if (roots != order) {
     /* if root finding fails use some benign LSP values instead */
     for (i = 0; i < order; i++) lsp[i] = (PI / order) * (float)i;


### PR DESCRIPTION
see https://github.com/drowe67/codec2/issues/59

With this change a static build of ffmpeg on alpine linux with both libspeex and libcodec2 enabled succeeds.